### PR TITLE
refactor: migrate data fetching to SWR

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,6 +8,8 @@ import { AuthProvider } from './src/contexts/auth';
 import Routes from './src/routes';
 import { setupAxiosMocks } from './src/mocks/axiosMock';
 import './src/i18n';
+import httpClient from './src/lib/httpClient';
+import { SWRConfig } from 'swr'
 
 const MyTheme = {
   ...DefaultTheme,
@@ -22,6 +24,8 @@ if (__DEV__) {
 }
 
 SplashScreen.preventAutoHideAsync();
+
+const fetcher = url => httpClient.get(url).then(res => res.data)
 
 export default function App() {
   const [loaded, error] = useFonts({
@@ -39,11 +43,13 @@ export default function App() {
   }
 
   return (
-    <NavigationContainer theme={MyTheme}>
-      <StatusBar />
-      <AuthProvider>
-        <Routes />
-      </AuthProvider>
-    </NavigationContainer>
+    <SWRConfig value={{ fetcher }}>
+      <NavigationContainer theme={MyTheme}>
+        <StatusBar />
+        <AuthProvider>
+          <Routes />
+        </AuthProvider>
+      </NavigationContainer>
+    </SWRConfig>
   );
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-native-web": "^0.21.0",
     "react-native-worklets": "0.5.1",
     "styled-components": "^6.1.19",
+    "swr": "^2.4.1",
     "yup": "^0.31.1"
   },
   "devDependencies": {

--- a/src/pages/Campaigns/index.js
+++ b/src/pages/Campaigns/index.js
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
 import { View, ActivityIndicator } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { FontAwesome5 } from '@expo/vector-icons';
+import useSWR from 'swr';
 import { getMyCampaigns } from '../../services/campaignService';
 
 import { Container } from '../../components/GlobalStyles';
@@ -18,26 +18,12 @@ const Campaigns = () => {
 
   const { id } = route.params;
 
-  const [campaignsList, setCampaignsList] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const { data, isLoading } = useSWR(['campaigns', id], () => getMyCampaigns(id), {
+    onError: (err) => console.log(err),
+  });
+  const campaignsList = data || [];
 
-  useEffect(() => {
-    const getCampaigns = async () => {
-      try {
-        const campaigns = await getMyCampaigns(id);
-
-        setCampaignsList(campaigns);
-      } catch (err) {
-        console.log(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    getCampaigns();
-  }, []);
-
-  if (loading) {
+  if (isLoading) {
     return (
       <Container center>
         <ActivityIndicator size="large" color="#fff" />

--- a/src/pages/MyVaccines/index.js
+++ b/src/pages/MyVaccines/index.js
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
 import { useRoute } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
+import useSWR from 'swr';
 
 import { VaccineList, Error, Loading } from './styles';
 
@@ -15,27 +15,11 @@ function MyVaccines() {
 
   const { id } = route.params;
 
-  const [vaccineList, setVaccineList] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState(null);
+  const { data, error, isLoading } = useSWR(['vaccineTimeline', id], () => getVaccineTimeline(id));
+  const vaccineList = data || [];
+  const errorMessage = error ? t('myVaccines.errorMessage') : null;
 
-  useEffect(() => {
-    const getVaccines = async () => {
-      try {
-        const vaccines = await getVaccineTimeline(id);
-
-        setVaccineList(vaccines);
-      } catch (err) {
-        setErrorMessage(t('myVaccines.errorMessage'));
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    getVaccines();
-  }, []);
-
-  if (loading)
+  if (isLoading)
     return (
       <Container center>
         <Loading />

--- a/src/pages/ProfileList/index.js
+++ b/src/pages/ProfileList/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import {
   FlatList,
   ActivityIndicator,
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
+import useSWR from 'swr'
 
 import { Container } from '../../components/GlobalStyles';
 import {
@@ -33,34 +34,21 @@ function ProfileList() {
   const { logout } = useAuth();
   const { t } = useTranslation();
 
-  const [profiles, setProfiles] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const { data, error, isLoading, mutate } = useSWR('user', getUser);
+  const profiles = data?.content?.dependentProfiles || [];
 
   useEffect(() => {
-    const getUserInfo = async () => {
-      try {
-        const data = await getUser();
-        const { dependentProfiles } = data.content;
-
-        setProfiles(dependentProfiles);
-        setError(false);
-      } catch (err) {
-        setError(true);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    getUserInfo();
-  }, [isFocused]);
+    if (isFocused) {
+      mutate();
+    }
+  }, [isFocused, mutate]);
 
   const ErrorPage = () => (
     <View>
       <Text>{t('profileList.errorTitle')}</Text>
 
       <Text>{t('profileList.errorSubtitle')}</Text>
-      <TouchableOpacity>
+      <TouchableOpacity onPress={() => mutate()}>
         <Text>{t('profileList.reloadButton')}</Text>
       </TouchableOpacity>
     </View>
@@ -117,7 +105,7 @@ function ProfileList() {
 
   const columns = 3;
 
-  if (loading)
+  if (isLoading)
     return (
       <Container center>
         <ActivityIndicator size="large" color="#fff" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,6 +2802,11 @@ depd@2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
@@ -6268,6 +6273,14 @@ svgo@^3.0.2:
     css-what "^6.1.0"
     csso "^5.0.5"
     picocolors "^1.0.0"
+
+swr@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.4.1.tgz#c9e48abff6bf4b04846342e2f1f6be108a078cf6"
+  integrity sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==
+  dependencies:
+    dequal "^2.0.3"
+    use-sync-external-store "^1.6.0"
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
## Description

Replaces manual `useState`/`useEffect`-based data fetching with [SWR](https://swr.vercel.app/) across the app, giving us automatic caching, deduplication, revalidation, and a cleaner component model.

**What changed:**
- Added a global `SWRConfig` in `App.js` with a shared `fetcher` backed by `httpClient`
- **ProfileList** — replaced manual fetch + state with `useSWR('user', getUser)`; uses `mutate()` to re-fetch on focus and on the retry button
- **Campaigns** — replaced fetch + state with `useSWR(['campaigns', id], ...)`; errors logged via the `onError` callback
- **MyVaccines** — replaced fetch + state with `useSWR(['vaccineTimeline', id], ...)`; error state derived from SWR's `error`
- Added `swr` to `package.json` / `yarn.lock`