### PR TITLE
refactor: replace formik and yup with react-hook-form and zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@expo-google-fonts/roboto": "^0.4.0",
     "@expo/vector-icons": "^15.0.3",
+    "@hookform/resolvers": "^5.8.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-picker/picker": "2.11.1",
@@ -28,10 +29,10 @@
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-updates": "~29.0.15",
-    "formik": "^2.2.5",
     "i18next": "^25.7.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-hook-form": "^7.85.0",
     "react-i18next": "^16.5.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
@@ -46,7 +47,7 @@
     "react-native-worklets": "0.5.1",
     "styled-components": "^6.1.19",
     "swr": "^2.5.1",
-    "yup": "^0.32.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/src/pages/AddDependent/index.tsx
+++ b/src/pages/AddDependent/index.tsx
@@ -48,7 +48,6 @@ function AddDependent() {
   const cpfRef = useRef<any>(null);
 
   const {
-    register,
     handleSubmit,
     control,
     setError,
@@ -95,8 +94,6 @@ function AddDependent() {
     }
   };
 
-  const nameField = register('name');
-
   return (
     <ScrollView
       showsVerticalScrollIndicator={false}
@@ -107,15 +104,23 @@ function AddDependent() {
           <Title>{t('addDependent.title')}</Title>
 
           <Label>{t('addDependent.nameLabel')}</Label>
-          <Input
-            placeholder={t('addDependent.namePlaceholder')}
-            onChange={nameField.onChange}
-            onBlur={nameField.onBlur}
-            ref={nameField.ref}
-            autoCapitalize="words"
-            returnKeyType="next"
-            onSubmitEditing={() => birthDateRef.current?.getElement().focus()}
-            blurOnSubmit={false}
+          <Controller
+            control={control}
+            name="name"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Input
+                placeholder={t('addDependent.namePlaceholder')}
+                value={value}
+                onChangeText={onChange}
+                onBlur={onBlur}
+                autoCapitalize="words"
+                returnKeyType="next"
+                onSubmitEditing={() =>
+                  birthDateRef.current?.getElement().focus()
+                }
+                blurOnSubmit={false}
+              />
+            )}
           />
           {touchedFields.name && errors.name && (
             <ErrorMessage>{errors.name.message}</ErrorMessage>

--- a/src/pages/AddDependent/index.tsx
+++ b/src/pages/AddDependent/index.tsx
@@ -1,11 +1,11 @@
 import { useRef } from 'react';
 import { ScrollView, View } from 'react-native';
-import { useFormik } from 'formik';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigation } from '@react-navigation/native';
-import * as yup from 'yup';
+import { z } from 'zod';
 import { Picker } from '@react-native-picker/picker';
 import { useTranslation } from 'react-i18next';
-import type { FormikHelpers } from 'formik';
 import {
   Container,
   ErrorMessage,
@@ -33,23 +33,39 @@ function AddDependent() {
   const navigation = useNavigation<NavigationProp>();
   const { t } = useTranslation();
 
-  const signUpSchema = yup.object({
-    name: yup.string().required(t('validation.nameRequired')),
-    birth_date: yup.string().required(t('validation.birthDateRequired')),
-    cpf: yup
+  const signUpSchema = z.object({
+    name: z.string().min(1, t('validation.nameRequired')),
+    birth_date: z.string().min(1, t('validation.birthDateRequired')),
+    cpf: z
       .string()
-      .min(11, t('validation.cpfMin'))
-      .required(t('validation.cpfRequired')),
-    gender: yup.string().required(t('validation.genderRequired')),
+      .min(1, t('validation.cpfRequired'))
+      .min(11, t('validation.cpfMin')),
+    gender: z.string().min(1, t('validation.genderRequired')),
+    general: z.string(),
   });
 
   const birthDateRef = useRef<any>(null);
   const cpfRef = useRef<any>(null);
 
-  const handleSignUp = async (
-    values: AddDependentValues,
-    actions: FormikHelpers<AddDependentValues>,
-  ) => {
+  const {
+    register,
+    handleSubmit,
+    control,
+    setError,
+    formState: { errors, isSubmitting, touchedFields },
+  } = useForm<AddDependentValues>({
+    resolver: zodResolver(signUpSchema),
+    defaultValues: {
+      name: '',
+      birth_date: '',
+      cpf: '',
+      gender: 'MALE',
+      general: '',
+    },
+    mode: 'onChange',
+  });
+
+  const handleSignUp = async (values: AddDependentValues) => {
     try {
       const completeName = values.name.split(' ');
 
@@ -75,31 +91,11 @@ function AddDependent() {
 
       navigation.goBack();
     } catch (error: any) {
-      actions.setFieldError('general', error.message);
+      setError('general', { message: error.message });
     }
-    actions.setSubmitting(false);
   };
 
-  const {
-    handleSubmit,
-    handleChange,
-    handleBlur,
-    setFieldValue,
-    touched,
-    errors,
-    values,
-    isSubmitting,
-  } = useFormik<AddDependentValues>({
-    initialValues: {
-      name: '',
-      birth_date: '',
-      cpf: '',
-      gender: 'MALE',
-      general: '',
-    },
-    onSubmit: handleSignUp,
-    validationSchema: signUpSchema,
-  });
+  const nameField = register('name');
 
   return (
     <ScrollView
@@ -113,78 +109,101 @@ function AddDependent() {
           <Label>{t('addDependent.nameLabel')}</Label>
           <Input
             placeholder={t('addDependent.namePlaceholder')}
-            onChangeText={handleChange('name')}
-            value={values.name}
-            onBlur={handleBlur('name')}
+            onChange={nameField.onChange}
+            onBlur={nameField.onBlur}
+            ref={nameField.ref}
             autoCapitalize="words"
             returnKeyType="next"
             onSubmitEditing={() => birthDateRef.current?.getElement().focus()}
             blurOnSubmit={false}
           />
-          {touched.name && errors.name && (
-            <ErrorMessage>{errors.name}</ErrorMessage>
+          {touchedFields.name && errors.name && (
+            <ErrorMessage>{errors.name.message}</ErrorMessage>
           )}
 
           <Label>{t('addDependent.birthDateLabel')}</Label>
-          <Input
-            masked
-            type="datetime"
-            options={{
-              format: 'DD/MM/YYYY',
-            }}
-            textContentType="birthdate"
-            maxLength={10}
-            placeholder={t('addDependent.birthDatePlaceholder')}
-            onChangeText={handleChange('birth_date')}
-            value={values.birth_date}
-            onBlur={handleBlur('birth_date')}
-            ref={birthDateRef}
-            returnKeyType="next"
-            onSubmitEditing={() => cpfRef.current?.getElement().focus()}
-            blurOnSubmit={false}
+          <Controller
+            control={control}
+            name="birth_date"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Input
+                masked
+                type="datetime"
+                options={{
+                  format: 'DD/MM/YYYY',
+                }}
+                textContentType="birthdate"
+                maxLength={10}
+                placeholder={t('addDependent.birthDatePlaceholder')}
+                value={value}
+                onChangeText={onChange}
+                onBlur={onBlur}
+                ref={birthDateRef}
+                returnKeyType="next"
+                onSubmitEditing={() => cpfRef.current?.getElement().focus()}
+                blurOnSubmit={false}
+              />
+            )}
           />
-          {touched.birth_date && errors.birth_date && (
-            <ErrorMessage>{errors.birth_date}</ErrorMessage>
+          {touchedFields.birth_date && errors.birth_date && (
+            <ErrorMessage>{errors.birth_date.message}</ErrorMessage>
           )}
 
           <Label>{t('addDependent.cpfLabel')}</Label>
-          <Input
-            masked
-            type="cpf"
-            maxLength={14}
-            placeholder={t('addDependent.cpfPlaceholder')}
-            onChangeText={handleChange('cpf')}
-            value={values.cpf}
-            onBlur={handleBlur('cpf')}
-            ref={cpfRef}
+          <Controller
+            control={control}
+            name="cpf"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Input
+                masked
+                type="cpf"
+                maxLength={14}
+                placeholder={t('addDependent.cpfPlaceholder')}
+                value={value}
+                onChangeText={onChange}
+                onBlur={onBlur}
+                ref={cpfRef}
+              />
+            )}
           />
-          {touched.cpf && errors.cpf && (
-            <ErrorMessage>{errors.cpf}</ErrorMessage>
+          {touchedFields.cpf && errors.cpf && (
+            <ErrorMessage>{errors.cpf.message}</ErrorMessage>
           )}
 
           <Label>{t('addDependent.genderLabel')}</Label>
-          <Select
-            mode="dropdown"
-            selectedValue={values.gender}
-            onValueChange={(itemValue) => setFieldValue('gender', itemValue)}
-            onBlur={handleBlur('gender')}
-            dropdownIconColor="#FFFFFF"
-          >
-            <Picker.Item label={t('addDependent.genderMale')} value="MALE" />
-            <Picker.Item
-              label={t('addDependent.genderFemale')}
-              value="FEMALE"
-            />
-          </Select>
-          {touched.gender && errors.gender && (
-            <ErrorMessage>{errors.gender}</ErrorMessage>
+          <Controller
+            control={control}
+            name="gender"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Select
+                mode="dropdown"
+                selectedValue={value}
+                onValueChange={onChange}
+                onBlur={onBlur}
+                dropdownIconColor="#FFFFFF"
+              >
+                <Picker.Item
+                  label={t('addDependent.genderMale')}
+                  value="MALE"
+                />
+                <Picker.Item
+                  label={t('addDependent.genderFemale')}
+                  value="FEMALE"
+                />
+              </Select>
+            )}
+          />
+          {touchedFields.gender && errors.gender && (
+            <ErrorMessage>{errors.gender.message}</ErrorMessage>
           )}
 
-          {errors.general && <ErrorMessage>{errors.general}</ErrorMessage>}
+          {errors.general && (
+            <ErrorMessage>{errors.general.message}</ErrorMessage>
+          )}
         </View>
 
         <View>
-          <Button onPress={handleSubmit} loading={isSubmitting}>
+          <Button onPress={handleSubmit(handleSignUp)} loading={isSubmitting}>
             {t('addDependent.createDependent')}
           </Button>
 

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from 'react';
 import { Keyboard, TextInput } from 'react-native';
-import { useFormik } from 'formik';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigation } from '@react-navigation/native';
-import * as yup from 'yup';
+import { z } from 'zod';
 import { useTranslation } from 'react-i18next';
-import type { FormikHelpers } from 'formik';
 import { Container, Input, ErrorMessage } from '../../components/GlobalStyles';
 import {
   Header,
@@ -35,15 +35,16 @@ function Login() {
   const navigation = useNavigation<NavigationProp>();
   const { login } = useAuth();
 
-  const loginSchema = yup.object({
-    email: yup
+  const loginSchema = z.object({
+    email: z
       .string()
-      .email(t('validation.emailInvalid'))
-      .required(t('validation.emailRequired')),
-    password: yup
+      .min(1, t('validation.emailRequired'))
+      .email(t('validation.emailInvalid')),
+    password: z
       .string()
-      .min(6, t('validation.passwordMin'))
-      .required(t('validation.passwordRequired')),
+      .min(1, t('validation.passwordRequired'))
+      .min(6, t('validation.passwordMin')),
+    general: z.string(),
   });
 
   const passwordRef = useRef<TextInput>(null);
@@ -54,10 +55,22 @@ function Login() {
     });
   }, []);
 
-  const handleLogin = async (
-    values: LoginValues,
-    actions: FormikHelpers<LoginValues>,
-  ) => {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting, isValid, touchedFields },
+  } = useForm<LoginValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+      general: '',
+    },
+    mode: 'onChange',
+  });
+
+  const handleLogin = async (values: LoginValues) => {
     Keyboard.dismiss();
 
     const { email, password } = values;
@@ -68,30 +81,12 @@ function Login() {
       const { error } = err.response.data;
 
       if (error === 'invalid_grant')
-        actions.setFieldError('general', t('validation.invalidCredentials'));
-
-      actions.setSubmitting(false);
+        setError('general', { message: t('validation.invalidCredentials') });
     }
   };
 
-  const {
-    handleChange,
-    handleBlur,
-    handleSubmit,
-    isSubmitting,
-    isValid,
-    values,
-    errors,
-    touched,
-  } = useFormik<LoginValues>({
-    initialValues: {
-      email: '',
-      password: '',
-      general: '',
-    },
-    validationSchema: loginSchema,
-    onSubmit: handleLogin,
-  });
+  const emailField = register('email');
+  const passwordField = register('password');
 
   return (
     <Container>
@@ -104,31 +99,33 @@ function Login() {
         <Logo width="94" height="150" />
       </Header>
 
-      {errors.general && <ErrorMessage>{errors.general}</ErrorMessage>}
+      {errors.general && <ErrorMessage>{errors.general.message}</ErrorMessage>}
 
       <Input
         placeholder={t('login.emailPlaceholder')}
         keyboardType="email-address"
         autoCapitalize="none"
-        onChangeText={handleChange('email')}
-        onBlur={handleBlur('email')}
-        value={values.email}
+        onChange={emailField.onChange}
+        onBlur={emailField.onBlur}
+        ref={emailField.ref}
       />
-      {touched.email && errors.email && (
-        <ErrorMessage>{errors.email}</ErrorMessage>
+      {touchedFields.email && errors.email && (
+        <ErrorMessage>{errors.email.message}</ErrorMessage>
       )}
       <Input
         placeholder={t('login.passwordPlaceholder')}
         secureTextEntry
-        ref={passwordRef}
         autoCapitalize="none"
-        onChangeText={handleChange('password')}
-        onBlur={handleBlur('password')}
-        value={values.password}
-        onSubmitEditing={() => handleSubmit()}
+        onChange={passwordField.onChange}
+        onBlur={passwordField.onBlur}
+        ref={(el: any) => {
+          passwordRef.current = el;
+          passwordField.ref(el);
+        }}
+        onSubmitEditing={() => handleSubmit(handleLogin)()}
       />
-      {touched.password && errors.password && (
-        <ErrorMessage>{errors.password}</ErrorMessage>
+      {touchedFields.password && errors.password && (
+        <ErrorMessage>{errors.password.message}</ErrorMessage>
       )}
 
       <ForgotPassword>
@@ -136,7 +133,7 @@ function Login() {
       </ForgotPassword>
 
       <Button
-        onPress={handleSubmit}
+        onPress={handleSubmit(handleLogin)}
         loading={isSubmitting}
         disabled={!isValid || isSubmitting}
       >

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Keyboard, TextInput } from 'react-native';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigation } from '@react-navigation/native';
 import { z } from 'zod';
@@ -56,7 +56,7 @@ function Login() {
   }, []);
 
   const {
-    register,
+    control,
     handleSubmit,
     setError,
     formState: { errors, isSubmitting, isValid, touchedFields },
@@ -85,9 +85,6 @@ function Login() {
     }
   };
 
-  const emailField = register('email');
-  const passwordField = register('password');
-
   return (
     <Container>
       <Edge
@@ -101,28 +98,38 @@ function Login() {
 
       {errors.general && <ErrorMessage>{errors.general.message}</ErrorMessage>}
 
-      <Input
-        placeholder={t('login.emailPlaceholder')}
-        keyboardType="email-address"
-        autoCapitalize="none"
-        onChange={emailField.onChange}
-        onBlur={emailField.onBlur}
-        ref={emailField.ref}
+      <Controller
+        control={control}
+        name="email"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Input
+            placeholder={t('login.emailPlaceholder')}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+          />
+        )}
       />
       {touchedFields.email && errors.email && (
         <ErrorMessage>{errors.email.message}</ErrorMessage>
       )}
-      <Input
-        placeholder={t('login.passwordPlaceholder')}
-        secureTextEntry
-        autoCapitalize="none"
-        onChange={passwordField.onChange}
-        onBlur={passwordField.onBlur}
-        ref={(el: any) => {
-          passwordRef.current = el;
-          passwordField.ref(el);
-        }}
-        onSubmitEditing={() => handleSubmit(handleLogin)()}
+      <Controller
+        control={control}
+        name="password"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Input
+            placeholder={t('login.passwordPlaceholder')}
+            secureTextEntry
+            autoCapitalize="none"
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            ref={passwordRef}
+            onSubmitEditing={() => handleSubmit(handleLogin)()}
+          />
+        )}
       />
       {touchedFields.password && errors.password && (
         <ErrorMessage>{errors.password.message}</ErrorMessage>

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,11 +1,11 @@
 import { useRef, useEffect } from 'react';
 import { ScrollView, TextInput } from 'react-native';
-import { useFormik } from 'formik';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigation } from '@react-navigation/native';
-import * as yup from 'yup';
+import { z } from 'zod';
 import { Picker } from '@react-native-picker/picker';
 import { useTranslation } from 'react-i18next';
-import type { FormikHelpers } from 'formik';
 import { ErrorMessage, Label, Select } from '../../components/GlobalStyles';
 import {
   Title,
@@ -21,7 +21,7 @@ import Input from '../../components/Input';
 import Button from '../../components/Button';
 
 import { useAuth } from '../../contexts/auth';
-import { register } from '../../services/auth/auth.service';
+import { register as registerUser } from '../../services/auth/auth.service';
 
 import type { NavigationProp } from '../../@types/navigation';
 
@@ -41,29 +41,34 @@ function SignUp() {
   const navigation = useNavigation<NavigationProp>();
   const { login } = useAuth();
 
-  const signUpSchema = yup.object({
-    name: yup.string().required(t('validation.nameRequired')),
-    email: yup.string().required(t('validation.emailRequired')),
-    birth_date: yup.string().required(t('validation.birthDateRequired')),
-    cpf: yup
-      .string()
-      .min(11, t('validation.cpfMin'))
-      .required(t('validation.cpfRequired')),
-    gender: yup.string().required(t('validation.genderRequired')),
-    password: yup
-      .string()
-      .min(6, t('validation.passwordMin'))
-      .required(t('validation.passwordRequired')),
-    confirm_password: yup
-      .string()
-      .min(6, t('validation.confirmPasswordMin'))
-      .required(t('validation.confirmPasswordRequired'))
-      .oneOf([yup.ref('password'), null], t('validation.passwordsMustMatch')),
-  });
+  const signUpSchema = z
+    .object({
+      name: z.string().min(1, t('validation.nameRequired')),
+      email: z.string().min(1, t('validation.emailRequired')),
+      birth_date: z.string().min(1, t('validation.birthDateRequired')),
+      cpf: z
+        .string()
+        .min(1, t('validation.cpfRequired'))
+        .min(11, t('validation.cpfMin')),
+      gender: z.string().min(1, t('validation.genderRequired')),
+      password: z
+        .string()
+        .min(1, t('validation.passwordRequired'))
+        .min(6, t('validation.passwordMin')),
+      confirm_password: z
+        .string()
+        .min(1, t('validation.confirmPasswordRequired'))
+        .min(6, t('validation.confirmPasswordMin')),
+      general: z.string(),
+    })
+    .refine((data) => data.password === data.confirm_password, {
+      message: t('validation.passwordsMustMatch'),
+      path: ['confirm_password'],
+    });
 
   const emailRef = useRef<TextInput>(null);
-  const birthDateRef = useRef<TextInput>(null);
-  const cpfRef = useRef<TextInput>(null);
+  const birthDateRef = useRef<any>(null);
+  const cpfRef = useRef<any>(null);
   const genderRef = useRef<any>(null);
   const passwordRef = useRef<TextInput>(null);
   const confirmPasswordRef = useRef<TextInput>(null);
@@ -77,10 +82,28 @@ function SignUp() {
     });
   }, []);
 
-  const handleSignUp = async (
-    values: SignUpValues,
-    actions: FormikHelpers<SignUpValues>,
-  ) => {
+  const {
+    register,
+    handleSubmit,
+    control,
+    setError,
+    formState: { errors, isSubmitting, touchedFields },
+  } = useForm<SignUpValues>({
+    resolver: zodResolver(signUpSchema),
+    defaultValues: {
+      name: '',
+      email: '',
+      birth_date: '',
+      cpf: '',
+      gender: 'MALE',
+      password: '',
+      confirm_password: '',
+      general: '',
+    },
+    mode: 'onChange',
+  });
+
+  const handleSignUp = async (values: SignUpValues) => {
     const completeName = values.name.split(' ');
 
     const birthOfDate = `${values.birth_date
@@ -105,39 +128,18 @@ function SignUp() {
     };
 
     try {
-      await register(data);
+      await registerUser(data);
 
       await login(values.email, values.password);
     } catch (error: any) {
-      actions.setFieldError('general', error.message);
+      setError('general', { message: error.message });
     }
-
-    actions.setSubmitting(false);
   };
 
-  const {
-    handleSubmit,
-    handleChange,
-    handleBlur,
-    setFieldValue,
-    touched,
-    errors,
-    values,
-    isSubmitting,
-  } = useFormik<SignUpValues>({
-    initialValues: {
-      name: '',
-      email: '',
-      birth_date: '',
-      cpf: '',
-      gender: 'MALE',
-      password: '',
-      confirm_password: '',
-      general: '',
-    },
-    onSubmit: handleSignUp,
-    validationSchema: signUpSchema,
-  });
+  const nameField = register('name');
+  const emailField = register('email');
+  const passwordField = register('password');
+  const confirmPasswordField = register('confirm_password');
 
   return (
     <ScrollView
@@ -149,111 +151,137 @@ function SignUp() {
       <Label>{t('signup.nameLabel')}</Label>
       <Input
         placeholder={t('signup.namePlaceholder')}
-        onChangeText={handleChange('name')}
-        value={values.name}
-        onBlur={handleBlur('name')}
+        onChange={nameField.onChange}
+        onBlur={nameField.onBlur}
+        ref={nameField.ref}
         returnKeyType="next"
         onSubmitEditing={() => emailRef.current?.focus()}
         blurOnSubmit={false}
       />
-      {touched.name && errors.name && (
-        <ErrorMessage>{errors.name}</ErrorMessage>
+      {touchedFields.name && errors.name && (
+        <ErrorMessage>{errors.name.message}</ErrorMessage>
       )}
 
       <Label>{t('signup.emailLabel')}</Label>
       <Input
         placeholder={t('signup.emailPlaceholder')}
         keyboardType="email-address"
-        onChangeText={handleChange('email')}
         autoCapitalize="none"
-        value={values.email}
-        onBlur={handleBlur('email')}
-        ref={emailRef}
+        onChange={emailField.onChange}
+        onBlur={emailField.onBlur}
+        ref={(el: any) => {
+          emailRef.current = el;
+          emailField.ref(el);
+        }}
         returnKeyType="next"
         onSubmitEditing={() => birthDateRef.current?.focus()}
         blurOnSubmit={false}
       />
-      {touched.email && errors.email && (
-        <ErrorMessage>{errors.email}</ErrorMessage>
+      {touchedFields.email && errors.email && (
+        <ErrorMessage>{errors.email.message}</ErrorMessage>
       )}
 
       <Label>{t('signup.birthDateLabel')}</Label>
-      <Input
-        masked
-        type="datetime"
-        options={{
-          format: 'DD/MM/YYYY',
-        }}
-        maxLength={10}
-        placeholder={t('signup.birthDatePlaceholder')}
-        onChangeText={handleChange('birth_date')}
-        value={values.birth_date}
-        onBlur={handleBlur('birth_date')}
-        ref={birthDateRef}
-        returnKeyType="next"
-        onSubmitEditing={() => cpfRef.current?.focus()}
-        blurOnSubmit={false}
+      <Controller
+        control={control}
+        name="birth_date"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Input
+            masked
+            type="datetime"
+            options={{
+              format: 'DD/MM/YYYY',
+            }}
+            maxLength={10}
+            placeholder={t('signup.birthDatePlaceholder')}
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            ref={birthDateRef}
+            returnKeyType="next"
+            onSubmitEditing={() => cpfRef.current?.focus()}
+            blurOnSubmit={false}
+          />
+        )}
       />
-      {touched.birth_date && errors.birth_date && (
-        <ErrorMessage>{errors.birth_date}</ErrorMessage>
+      {touchedFields.birth_date && errors.birth_date && (
+        <ErrorMessage>{errors.birth_date.message}</ErrorMessage>
       )}
 
       <Label>{t('signup.cpfLabel')}</Label>
-      <Input
-        masked
-        type="cpf"
-        maxLength={14}
-        placeholder={t('signup.cpfPlaceholder')}
-        onChangeText={handleChange('cpf')}
-        value={values.cpf}
-        onBlur={handleBlur('cpf')}
-        ref={cpfRef}
-        returnKeyType="next"
-        onSubmitEditing={() => genderRef.current?.focus()}
-        blurOnSubmit={false}
+      <Controller
+        control={control}
+        name="cpf"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Input
+            masked
+            type="cpf"
+            maxLength={14}
+            placeholder={t('signup.cpfPlaceholder')}
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            ref={cpfRef}
+            returnKeyType="next"
+            onSubmitEditing={() => genderRef.current?.focus()}
+            blurOnSubmit={false}
+          />
+        )}
       />
-      {touched.cpf && errors.cpf && <ErrorMessage>{errors.cpf}</ErrorMessage>}
+      {touchedFields.cpf && errors.cpf && (
+        <ErrorMessage>{errors.cpf.message}</ErrorMessage>
+      )}
 
       <Label>{t('signup.genderLabel')}</Label>
-      <Select
-        selectedValue={values.gender}
-        onValueChange={(itemValue) => setFieldValue('gender', itemValue)}
-        onBlur={handleBlur('gender')}
-      >
-        <Picker.Item label={t('signup.genderMale')} value="MALE" />
-        <Picker.Item label={t('signup.genderFemale')} value="FEMALE" />
-      </Select>
-      {touched.gender && errors.gender && (
-        <ErrorMessage>{errors.gender}</ErrorMessage>
+      <Controller
+        control={control}
+        name="gender"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Select
+            selectedValue={value}
+            onValueChange={onChange}
+            onBlur={onBlur}
+          >
+            <Picker.Item label={t('signup.genderMale')} value="MALE" />
+            <Picker.Item label={t('signup.genderFemale')} value="FEMALE" />
+          </Select>
+        )}
+      />
+      {touchedFields.gender && errors.gender && (
+        <ErrorMessage>{errors.gender.message}</ErrorMessage>
       )}
 
       <Label>{t('signup.passwordLabel')}</Label>
       <Input
         placeholder={t('signup.passwordPlaceholder')}
         secureTextEntry
-        onChangeText={handleChange('password')}
-        value={values.password}
-        onBlur={handleBlur('password')}
-        ref={passwordRef}
+        onChange={passwordField.onChange}
+        onBlur={passwordField.onBlur}
+        ref={(el: any) => {
+          passwordRef.current = el;
+          passwordField.ref(el);
+        }}
         returnKeyType="next"
         onSubmitEditing={() => confirmPasswordRef.current?.focus()}
         blurOnSubmit={false}
       />
-      {touched.password && errors.password && (
-        <ErrorMessage>{errors.password}</ErrorMessage>
+      {touchedFields.password && errors.password && (
+        <ErrorMessage>{errors.password.message}</ErrorMessage>
       )}
 
       <Label>{t('signup.confirmPasswordLabel')}</Label>
       <Input
         placeholder={t('signup.confirmPasswordPlaceholder')}
         secureTextEntry
-        onChangeText={handleChange('confirm_password')}
-        value={values.confirm_password}
-        onBlur={handleBlur('confirm_password')}
-        ref={confirmPasswordRef}
+        onChange={confirmPasswordField.onChange}
+        onBlur={confirmPasswordField.onBlur}
+        ref={(el: any) => {
+          confirmPasswordRef.current = el;
+          confirmPasswordField.ref(el);
+        }}
       />
-      {touched.confirm_password && errors.confirm_password && (
-        <ErrorMessage>{errors.confirm_password}</ErrorMessage>
+      {touchedFields.confirm_password && errors.confirm_password && (
+        <ErrorMessage>{errors.confirm_password.message}</ErrorMessage>
       )}
 
       <TermsAndConditions>
@@ -265,9 +293,9 @@ function SignUp() {
         </TermsAndConditionsLink>
       </TermsAndConditions>
 
-      {errors.general && <ErrorMessage>{errors.general}</ErrorMessage>}
+      {errors.general && <ErrorMessage>{errors.general.message}</ErrorMessage>}
 
-      <Button onPress={handleSubmit} loading={isSubmitting}>
+      <Button onPress={handleSubmit(handleSignUp)} loading={isSubmitting}>
         {t('signup.createAccount')}
       </Button>
 

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -83,9 +83,8 @@ function SignUp() {
   }, []);
 
   const {
-    register,
-    handleSubmit,
     control,
+    handleSubmit,
     setError,
     formState: { errors, isSubmitting, touchedFields },
   } = useForm<SignUpValues>({
@@ -136,11 +135,6 @@ function SignUp() {
     }
   };
 
-  const nameField = register('name');
-  const emailField = register('email');
-  const passwordField = register('password');
-  const confirmPasswordField = register('confirm_password');
-
   return (
     <ScrollView
       showsVerticalScrollIndicator={false}
@@ -149,33 +143,43 @@ function SignUp() {
       <Title>{t('signup.title')}</Title>
 
       <Label>{t('signup.nameLabel')}</Label>
-      <Input
-        placeholder={t('signup.namePlaceholder')}
-        onChange={nameField.onChange}
-        onBlur={nameField.onBlur}
-        ref={nameField.ref}
-        returnKeyType="next"
-        onSubmitEditing={() => emailRef.current?.focus()}
-        blurOnSubmit={false}
+      <Controller
+        control={control}
+        name="name"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Input
+            placeholder={t('signup.namePlaceholder')}
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            returnKeyType="next"
+            onSubmitEditing={() => emailRef.current?.focus()}
+            blurOnSubmit={false}
+          />
+        )}
       />
       {touchedFields.name && errors.name && (
         <ErrorMessage>{errors.name.message}</ErrorMessage>
       )}
 
       <Label>{t('signup.emailLabel')}</Label>
-      <Input
-        placeholder={t('signup.emailPlaceholder')}
-        keyboardType="email-address"
-        autoCapitalize="none"
-        onChange={emailField.onChange}
-        onBlur={emailField.onBlur}
-        ref={(el: any) => {
-          emailRef.current = el;
-          emailField.ref(el);
-        }}
-        returnKeyType="next"
-        onSubmitEditing={() => birthDateRef.current?.focus()}
-        blurOnSubmit={false}
+      <Controller
+        control={control}
+        name="email"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Input
+            placeholder={t('signup.emailPlaceholder')}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            ref={emailRef}
+            returnKeyType="next"
+            onSubmitEditing={() => birthDateRef.current?.focus()}
+            blurOnSubmit={false}
+          />
+        )}
       />
       {touchedFields.email && errors.email && (
         <ErrorMessage>{errors.email.message}</ErrorMessage>
@@ -252,33 +256,41 @@ function SignUp() {
       )}
 
       <Label>{t('signup.passwordLabel')}</Label>
-      <Input
-        placeholder={t('signup.passwordPlaceholder')}
-        secureTextEntry
-        onChange={passwordField.onChange}
-        onBlur={passwordField.onBlur}
-        ref={(el: any) => {
-          passwordRef.current = el;
-          passwordField.ref(el);
-        }}
-        returnKeyType="next"
-        onSubmitEditing={() => confirmPasswordRef.current?.focus()}
-        blurOnSubmit={false}
+      <Controller
+        control={control}
+        name="password"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Input
+            placeholder={t('signup.passwordPlaceholder')}
+            secureTextEntry
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            ref={passwordRef}
+            returnKeyType="next"
+            onSubmitEditing={() => confirmPasswordRef.current?.focus()}
+            blurOnSubmit={false}
+          />
+        )}
       />
       {touchedFields.password && errors.password && (
         <ErrorMessage>{errors.password.message}</ErrorMessage>
       )}
 
       <Label>{t('signup.confirmPasswordLabel')}</Label>
-      <Input
-        placeholder={t('signup.confirmPasswordPlaceholder')}
-        secureTextEntry
-        onChange={confirmPasswordField.onChange}
-        onBlur={confirmPasswordField.onBlur}
-        ref={(el: any) => {
-          confirmPasswordRef.current = el;
-          confirmPasswordField.ref(el);
-        }}
+      <Controller
+        control={control}
+        name="confirm_password"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Input
+            placeholder={t('signup.confirmPasswordPlaceholder')}
+            secureTextEntry
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            ref={confirmPasswordRef}
+          />
+        )}
       />
       {touchedFields.confirm_password && errors.confirm_password && (
         <ErrorMessage>{errors.confirm_password.message}</ErrorMessage>

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,11 +840,6 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.27.1"
 
-"@babel/runtime@^7.15.4":
-  version "7.29.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
-  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
-
 "@babel/runtime@^7.18.6", "@babel/runtime@^7.20.0", "@babel/runtime@^7.25.0":
   version "7.27.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
@@ -1311,6 +1306,13 @@
     find-up "^5.0.0"
     js-yaml "^4.1.0"
 
+"@hookform/resolvers@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-5.8.0.tgz#164d440d61978be92bc1b18204daae3660591b8b"
+  integrity sha512-2m6GvRLmYYK1Fwt093lGMf7db9l/+8pNuAtwoNkpBntJT4xcA5lNthYGWKViOc3z2SuaPD0HjE81pyXmqc1JyA==
+  dependencies:
+    "@standard-schema/utils" "^0.3.0"
+
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz#fb907624df3256d04b9aa2df50d7aa97ec648748"
@@ -1719,6 +1721,11 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
+
 "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz#4001f5d5dd87fa13303e36ee106e3ff3a7eb8b22"
@@ -1889,11 +1896,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
-
-"@types/lodash@^4.14.175":
-  version "4.17.25"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.25.tgz#69765ac7bcddb0eb072961cf292524a8f5b3c2c0"
-  integrity sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==
 
 "@types/node@*":
   version "24.0.10"
@@ -3070,11 +3072,6 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
-  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
-
 deepmerge@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
@@ -4016,19 +4013,6 @@ for-each@^0.3.3, for-each@^0.3.5:
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
-
-formik@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.5.tgz#addf4ed7a15ebddf22c883a3d358cd27c8a91a55"
-  integrity sha512-KkOsyYmh5xsow+wlbdL9QSkqvbiHSb1RIToBKiooCFW4lyypn+ZlHGjTuuOqUWBqZaI5nCEupeI275Mo6tFBzg==
-  dependencies:
-    deepmerge "^2.1.1"
-    hoist-non-react-statics "^3.3.0"
-    lodash "^4.17.14"
-    lodash-es "^4.17.14"
-    react-fast-compare "^2.0.1"
-    tiny-warning "^1.0.2"
-    tslib "^1.10.0"
 
 freeport-async@^2.0.0:
   version "2.0.0"
@@ -5086,16 +5070,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.14:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
-
-lodash-es@^4.17.21:
-  version "4.18.1"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
-  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -5111,15 +5085,10 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
-lodash@^4.17.14, lodash@^4.17.19:
+lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.21:
-  version "4.18.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
-  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -5540,11 +5509,6 @@ mz@^2.7.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
-
-nanoclone@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
-  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@^3.3.11, nanoid@^3.3.7:
   version "3.3.11"
@@ -6050,11 +6014,6 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-property-expr@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.4.tgz#37b925478e58965031bb612ec5b3260f8241e910"
-  integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
-
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -6122,15 +6081,15 @@ react-dom@19.1.0:
   dependencies:
     scheduler "^0.26.0"
 
-react-fast-compare@^2.0.1:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
-  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
-
 react-freeze@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.4.tgz#cbbea2762b0368b05cbe407ddc9d518c57c6f3ad"
   integrity sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==
+
+react-hook-form@^7.85.0:
+  version "7.85.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.85.0.tgz#45b95cc794f9ed752ffc9121cc6ddcc92e97acf0"
+  integrity sha512-U2MTriFXnclmV4rOE20p2DcRFv5WEg3FIcBFOKcOLFHDVvGIMPvLTkTWefUsonmlaVy23khVDxDWym6uJVGOzw==
 
 react-i18next@^16.5.0:
   version "16.5.0"
@@ -7149,11 +7108,6 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-tiny-warning@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
 tinyglobby@^0.2.11:
   version "0.2.15"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
@@ -7202,11 +7156,6 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-toposort@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
-  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
-
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -7236,11 +7185,6 @@ tslib@2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
-
-tslib@^1.10.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.3:
   version "2.8.1"
@@ -7695,15 +7639,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-yup@^0.32.0:
-  version "0.32.11"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.11.tgz#d67fb83eefa4698607982e63f7ca4c5ed3cf18c5"
-  integrity sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@types/lodash" "^4.14.175"
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
-    nanoclone "^0.2.1"
-    property-expr "^2.0.4"
-    toposort "^2.0.2"
+zod@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary
Replaces **Formik + Yup** with **React Hook Form + Zod** across the three form pages (Login, SignUp, AddDependent).

## Changes
- Removed `formik` and `yup`; added `react-hook-form`, `zod`, `@hookform/resolvers`
- Migrated yup schemas to zod (`zodResolver`), including the cross-field password match via `.refine()`
- Migrated all form state handling to `useForm` (`handleSubmit`, `setError`, `formState`)
- Used `Controller` for all inputs (required for React Native: `register()` reads `event.target.name` and silently drops RN native events)
- Masked inputs (`react-native-masked-text`) and the gender `Picker` are wired via `Controller` with `onChangeText`/`onValueChange`
- Server errors map to the `general` field via `setError` (was `setFieldError`)

## Validation
- `npx tsc --noEmit` passes
- `yarn lint` passes
- No test suite in the repo