### PR TITLE
test: add jest test coverage across services, components and pages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -91,7 +91,8 @@
         "**/*.test.tsx",
         "**/*.spec.ts",
         "**/*.spec.tsx",
-        "**/__tests__/**"
+        "**/__tests__/**",
+        "src/testUtils.tsx"
       ],
       "env": {
         "jest": true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -103,7 +103,10 @@
           {
             "devDependencies": true
           }
-        ]
+        ],
+        "@typescript-eslint/no-require-imports": "off",
+        "global-require": "off",
+        "react/function-component-definition": "off"
       }
     }
   ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -77,6 +77,33 @@
         "@typescript-eslint/no-var-requires": "off",
         "func-names": "off"
       }
+    },
+    {
+      "files": ["jest/**"],
+      "rules": {
+        "@typescript-eslint/no-require-imports": "off",
+        "global-require": "off"
+      }
+    },
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "**/__tests__/**"
+      ],
+      "env": {
+        "jest": true
+      },
+      "rules": {
+        "import/no-extraneous-dependencies": [
+          "error",
+          {
+            "devDependencies": true
+          }
+        ]
+      }
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ environment.ts
 
 # local backlog
 BACKLOG.local.md
+
+# tests
+coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ map. Uses a backend API via Axios.
 - styled-components for styling
 - SWR for data fetching
 - i18next (pt-BR + en-US)
-- Formik + Yup for forms
+- React Hook Form + Zod (zodResolver) for forms
 - Axios for HTTP (single shared instance)
 - State managed via React Context
 
@@ -41,9 +41,10 @@ map. Uses a backend API via Axios.
   (`environment$` → `jest/environmentMock.ts`).
 - Service/page tests should mock the service module (or `src/lib/httpClient`),
   not SWR, so SWR loading/error paths are exercised.
-- Form pages (Formik + Yup) will be rewritten to Zod in a separate branch;
-  their tests come after that migration. Do not write Formik/Yup-coupled tests
-  for `Login`, `SignUp`, `AddDependent` yet.
+- Form pages use `react-hook-form` `Controller` + `zodResolver`; their tests
+  render the page and drive the inputs with RNTL `fireEvent` (changeText/blur),
+  asserting validation messages (i18n keys) and that submit calls the mocked
+  service/context functions.
 - Run `npx tsc --noEmit` and `yarn lint` alongside `yarn test`; test files must
   satisfy `strict` + `noUncheckedIndexedAccess`.
 
@@ -63,7 +64,7 @@ map. Uses a backend API via Axios.
   SWR hooks to consume them.
 - All user-facing strings must use i18n keys via `useTranslation()` and live in
   `src/i18n/locales/{en-US,pt-BR}/translation.json`. Keep both locales in sync.
-- Forms use Formik + Yup, with validation messages from i18n keys.
+- Forms use React Hook Form + Zod, with validation messages from i18n keys.
 - Authentication state lives in `src/contexts/auth.tsx`; the Axios instance
   keeps the Bearer token in its default headers.
 - Imports follow the pattern: react, third-party libs, local modules, then assets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,28 @@ map. Uses a backend API via Axios.
 - `yarn start` — start Expo dev server
 - `yarn lint` — run ESLint (`eslint . --ext .js,.jsx,.ts,.tsx`)
 - `npx tsc --noEmit` — typecheck (tsconfig exists, but no script is defined)
+- `yarn test` / `yarn test:watch` — run Jest (jest-expo preset)
 - `yarn ios` / `yarn android` — run on device/simulator
 - `yarn web` — start web build
 
-There is no test suite. TypeScript is compiled through the bundler; use
-`npx tsc --noEmit` to typecheck.
+## Testing
+
+- Jest + jest-expo preset, `@testing-library/react-native` for component/page
+  tests. No test suite existed before; tests live next to source as
+  `*.test.ts(x)`.
+- Test infra lives in `jest/` (`setup.ts`, `svgMock.ts`, `environmentMock.ts`).
+  `jest/setup.ts` mocks `react-i18next` (`t` returns the key) and
+  `@react-native-async-storage/async-storage` uses its official Jest mock
+  (wired via `moduleNameMapper`).
+- `environment.ts` is gitignored; tests resolve it via `moduleNameMapper`
+  (`environment$` → `jest/environmentMock.ts`).
+- Service/page tests should mock the service module (or `src/lib/httpClient`),
+  not SWR, so SWR loading/error paths are exercised.
+- Form pages (Formik + Yup) will be rewritten to Zod in a separate branch;
+  their tests come after that migration. Do not write Formik/Yup-coupled tests
+  for `Login`, `SignUp`, `AddDependent` yet.
+- Run `npx tsc --noEmit` and `yarn lint` alongside `yarn test`; test files must
+  satisfy `strict` + `noUncheckedIndexedAccess`.
 
 ## Conventions
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  preset: 'jest-expo',
+  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+  moduleNameMapper: {
+    '^@react-native-async-storage/async-storage$':
+      '@react-native-async-storage/async-storage/jest/async-storage-mock',
+    '\\.svg$': '<rootDir>/jest/svgMock.ts',
+    environment$: '<rootDir>/jest/environmentMock.ts',
+  },
+  setupFiles: [
+    '<rootDir>/jest/setup.ts',
+    'react-native-gesture-handler/jestSetup',
+  ],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/mocks/**',
+    '!src/i18n/index.ts',
+  ],
+};

--- a/jest/environmentMock.ts
+++ b/jest/environmentMock.ts
@@ -1,0 +1,15 @@
+interface EnvVars {
+  apiUrl: string;
+  clientId: string;
+  secret: string;
+}
+
+const ENV: EnvVars = {
+  apiUrl: 'http://localhost:3000',
+  clientId: 'test-client',
+  secret: 'test-secret',
+};
+
+export default function getEnvVars(): EnvVars {
+  return ENV;
+}

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -10,6 +10,37 @@ jest.mock('react-i18next', () => {
   };
 });
 
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  const iconNames = [
+    'FontAwesome',
+    'FontAwesome5',
+    'MaterialIcons',
+    'MaterialCommunityIcons',
+    'Foundation',
+    'Ionicons',
+    'Feather',
+    'Entypo',
+    'AntDesign',
+    'SimpleLineIcons',
+  ];
+
+  const icons: Record<
+    string,
+    React.ComponentType<Record<string, unknown>>
+  > = {};
+
+  iconNames.forEach((name) => {
+    icons[name] = function IconMock(props: Record<string, unknown>) {
+      return React.createElement(Text, props, name);
+    };
+  });
+
+  return icons;
+});
+
 jest.mock('react-native-gesture-handler', () => {
   const React = require('react');
   const { TouchableOpacity } = require('react-native');

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -1,0 +1,40 @@
+jest.mock('react-i18next', () => {
+  const t = (key: string) => key;
+
+  return {
+    useTranslation: () => ({ t, i18n: { language: 'en-US' } }),
+    initReactI18next: {
+      type: '3rdParty',
+      init: jest.fn(),
+    },
+  };
+});
+
+jest.mock('react-native-gesture-handler', () => {
+  const React = require('react');
+  const { TouchableOpacity } = require('react-native');
+
+  function ButtonComponent({
+    children,
+    onPress,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+  }) {
+    return React.createElement(
+      TouchableOpacity,
+      { onPress, ...rest },
+      children,
+    );
+  }
+
+  return {
+    RectButton: ButtonComponent,
+    BaseButton: ButtonComponent,
+    RawButton: ButtonComponent,
+    BorderlessButton: ButtonComponent,
+    ScrollView: require('react-native').ScrollView,
+    State: {},
+  };
+});

--- a/jest/svgMock.ts
+++ b/jest/svgMock.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+function SvgMock(props: ViewProps) {
+  return React.createElement(View, props);
+}
+
+export default SvgMock;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "eject": "expo eject"
+    "eject": "expo eject",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@expo-google-fonts/roboto": "^0.4.0",
@@ -51,6 +53,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
+    "@testing-library/react-native": "^13",
+    "@types/jest": "^29",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^8",
@@ -63,7 +67,10 @@
     "eslint-plugin-prettier": "^5",
     "eslint-plugin-react": "^7",
     "eslint-plugin-react-hooks": "^5",
+    "jest": "~29.7.0",
+    "jest-expo": "~54.0.0",
     "prettier": "^3",
+    "react-test-renderer": "19.1.0",
     "typescript": "^5.9.2"
   },
   "private": true,

--- a/src/components/Button/index.test.tsx
+++ b/src/components/Button/index.test.tsx
@@ -1,0 +1,34 @@
+import { ActivityIndicator } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import Button from '.';
+
+describe('Button', () => {
+  it('renders its children', () => {
+    const { getByText } = render(<Button onPress={() => {}}>Submit</Button>);
+
+    expect(getByText('Submit')).toBeTruthy();
+  });
+
+  it('shows a loading indicator instead of children while loading', () => {
+    // eslint-disable-next-line camelcase
+    const { queryByText, UNSAFE_getByType } = render(
+      <Button onPress={() => {}} loading>
+        Submit
+      </Button>,
+    );
+
+    expect(queryByText('Submit')).toBeNull();
+    // eslint-disable-next-line camelcase
+    expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+  });
+
+  it('calls onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<Button onPress={onPress}>Submit</Button>);
+
+    fireEvent.press(getByText('Submit'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Input/index.test.tsx
+++ b/src/components/Input/index.test.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable camelcase */
+import { TextInput } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import Input from '.';
+
+describe('Input', () => {
+  it('renders a plain text input when not masked', () => {
+    const { UNSAFE_getByType } = render(<Input placeholder="Name" />);
+
+    expect(UNSAFE_getByType(TextInput)).toBeTruthy();
+  });
+
+  it('forwards text input props', () => {
+    const onChangeText = jest.fn();
+    const { getByPlaceholderText } = render(
+      <Input placeholder="Name" onChangeText={onChangeText} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Name'), 'John');
+
+    expect(onChangeText).toHaveBeenCalledWith('John');
+  });
+
+  it('renders a masked input when masked is true', () => {
+    const { UNSAFE_getByType } = render(<Input masked type="cpf" />);
+
+    expect(UNSAFE_getByType(TextInput)).toBeTruthy();
+  });
+});

--- a/src/components/VaccineCard/index.test.tsx
+++ b/src/components/VaccineCard/index.test.tsx
@@ -1,0 +1,118 @@
+/* eslint-disable camelcase */
+import { render, fireEvent } from '@testing-library/react-native';
+import type { TFunction } from 'i18next';
+
+import { Foundation, MaterialCommunityIcons } from '@expo/vector-icons';
+
+import VaccineCard, { formatAgeRange, getNextVaccines } from '.';
+
+import type { Vaccine, VaccineTimelineItem } from '../../@types/models';
+
+function makeVaccine(overrides: Partial<Vaccine> = {}): Vaccine {
+  return {
+    name: 'BCG',
+    preventedDiseases: 'tuberculosis',
+    initialRange: 0,
+    finalRange: 0,
+    observation: '',
+    dosage: 'DOSAGE_UNIQUE',
+    range: 'INFANT',
+    requirement: null,
+    nextVaccine: null,
+    ...overrides,
+  };
+}
+
+function makeItem(vaccine: Vaccine = makeVaccine()): VaccineTimelineItem {
+  return { vaccine, applied: false };
+}
+
+describe('getNextVaccines', () => {
+  it('returns zeroes for a null chain', () => {
+    expect(getNextVaccines(null)).toEqual({
+      numberVaccines: 0,
+      numberAppliedVaccines: 0,
+    });
+  });
+
+  it('counts vaccines and applied vaccines along the chain', () => {
+    const last = makeVaccine({ name: 'Hepatitis B', applied: true });
+    const middle = makeVaccine({
+      name: 'BCG booster',
+      applied: false,
+      nextVaccine: last,
+    });
+    const first = makeVaccine({
+      name: 'BCG',
+      applied: true,
+      nextVaccine: middle,
+    });
+
+    expect(getNextVaccines(first)).toEqual({
+      numberVaccines: 3,
+      numberAppliedVaccines: 2,
+    });
+  });
+});
+
+describe('formatAgeRange', () => {
+  const t = jest.fn((key: string) => key) as unknown as TFunction & jest.Mock;
+
+  it('returns atBirth when the range starts at 0', () => {
+    expect(formatAgeRange(0, 0, t)).toBe('vaccineCard.atBirth');
+    expect(t).toHaveBeenCalledWith('vaccineCard.atBirth');
+  });
+
+  it('formats month ranges', () => {
+    const result = formatAgeRange(2, 6, t);
+
+    expect(result).toBe('vaccineCard.ageRange');
+    expect(t).toHaveBeenCalledWith('vaccineCard.ageMonth', { count: 2 });
+    expect(t).toHaveBeenCalledWith('vaccineCard.ageMonth', { count: 6 });
+  });
+
+  it('formats year ranges for values above 15 months', () => {
+    const result = formatAgeRange(24, 48, t);
+
+    expect(result).toBe('vaccineCard.ageRange');
+    expect(t).toHaveBeenCalledWith('vaccineCard.ageYear', { count: 2 });
+    expect(t).toHaveBeenCalledWith('vaccineCard.ageYear', { count: 4 });
+  });
+
+  it('returns a single value when the range is a point', () => {
+    expect(formatAgeRange(6, 6, t)).toBe('vaccineCard.ageMonth');
+  });
+});
+
+describe('VaccineCard', () => {
+  it('renders the vaccine name and dose label', () => {
+    const item = makeItem(makeVaccine({ dosage: 'DOSAGE_1' }));
+
+    const { getByText } = render(<VaccineCard item={item} />);
+
+    expect(getByText('BCG')).toBeTruthy();
+    expect(getByText('vaccineCard.dose')).toBeTruthy();
+  });
+
+  it('toggles the observation details', () => {
+    const item = makeItem(makeVaccine({ observation: 'special care' }));
+
+    const { queryByText, UNSAFE_getByType } = render(
+      <VaccineCard item={item} />,
+    );
+
+    expect(queryByText('vaccineCard.observation')).toBeNull();
+
+    fireEvent.press(UNSAFE_getByType(MaterialCommunityIcons));
+
+    expect(queryByText('vaccineCard.observation')).toBeTruthy();
+  });
+
+  it('renders the gender badge for GIRL vaccines', () => {
+    const item = makeItem(makeVaccine({ requirement: 'GIRL' }));
+
+    const { UNSAFE_getByType } = render(<VaccineCard item={item} />);
+
+    expect(UNSAFE_getByType(Foundation)).toBeTruthy();
+  });
+});

--- a/src/components/VaccineCard/index.tsx
+++ b/src/components/VaccineCard/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   FontAwesome5,
   MaterialIcons,
@@ -20,6 +21,53 @@ import {
   Details,
   Ball,
 } from './styles';
+
+export function getNextVaccines(vaccine: Vaccine | null): {
+  numberVaccines: number;
+  numberAppliedVaccines: number;
+} {
+  let currentVaccine = vaccine;
+
+  let numberVaccines = 0;
+  let numberAppliedVaccines = 0;
+
+  while (currentVaccine) {
+    numberVaccines += 1;
+    numberAppliedVaccines += currentVaccine.applied ? 1 : 0;
+
+    currentVaccine = currentVaccine.nextVaccine;
+  }
+
+  return { numberVaccines, numberAppliedVaccines };
+}
+
+export function formatAgeRange(
+  initialRangeValue: number,
+  finalRangeValue: number,
+  t: TFunction,
+): string {
+  if (initialRangeValue === 0) {
+    return t('vaccineCard.atBirth');
+  }
+
+  const isYears = initialRangeValue > 15;
+  const initialValue = isYears ? initialRangeValue / 12 : initialRangeValue;
+  const finalValue = isYears ? finalRangeValue / 12 : finalRangeValue;
+  const translationKey = isYears
+    ? 'vaccineCard.ageYear'
+    : 'vaccineCard.ageMonth';
+
+  const initialText = t(translationKey, { count: initialValue });
+  const finalText = t(translationKey, { count: finalValue });
+
+  if (initialValue !== finalValue) {
+    return t('vaccineCard.ageRange', {
+      initial: initialText,
+      final: finalText,
+    });
+  }
+  return initialText;
+}
 
 interface VaccineCardProps {
   item: VaccineTimelineItem;
@@ -57,53 +105,10 @@ function VaccineCard({ item }: VaccineCardProps) {
   };
 
   useEffect(() => {
-    const getNextVaccines = (vaccine: Vaccine | null) => {
-      let currentVaccine = vaccine;
-
-      let numberVaccines = 0;
-      let numberAppliedVaccines = 0;
-
-      while (currentVaccine) {
-        numberVaccines += 1;
-        numberAppliedVaccines += currentVaccine.applied ? 1 : 0;
-
-        currentVaccine = currentVaccine.nextVaccine;
-      }
-
-      return { numberVaccines, numberAppliedVaccines };
-    };
-
     setNumberDoses(getNextVaccines(nextVaccine));
   }, [nextVaccine]);
 
-  const formatAgeRange = (
-    initialRangeValue: number,
-    finalRangeValue: number,
-  ) => {
-    if (initialRangeValue === 0) {
-      return t('vaccineCard.atBirth');
-    }
-
-    const isYears = initialRangeValue > 15;
-    const initialValue = isYears ? initialRangeValue / 12 : initialRangeValue;
-    const finalValue = isYears ? finalRangeValue / 12 : finalRangeValue;
-    const translationKey = isYears
-      ? 'vaccineCard.ageYear'
-      : 'vaccineCard.ageMonth';
-
-    const initialText = t(translationKey, { count: initialValue });
-    const finalText = t(translationKey, { count: finalValue });
-
-    if (initialValue !== finalValue) {
-      return t('vaccineCard.ageRange', {
-        initial: initialText,
-        final: finalText,
-      });
-    }
-    return initialText;
-  };
-
-  const applicationRange = formatAgeRange(initialRange, finalRange);
+  const applicationRange = formatAgeRange(initialRange, finalRange, t);
 
   return (
     <Card>

--- a/src/contexts/auth.test.tsx
+++ b/src/contexts/auth.test.tsx
@@ -1,0 +1,117 @@
+import { Text } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { render, waitFor, act, fireEvent } from '@testing-library/react-native';
+
+import httpClient from '../lib/httpClient';
+import { login as authLogin } from '../services/auth/auth.service';
+import { AuthProvider, useAuth } from './auth';
+
+jest.mock('../lib/httpClient', () => ({
+  __esModule: true,
+  default: {
+    defaults: { headers: {} },
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('../services/auth/auth.service', () => ({
+  login: jest.fn(),
+}));
+
+const mockedAuthLogin = authLogin as jest.Mock;
+const mockedGetItem = AsyncStorage.getItem as jest.Mock;
+const mockedSetItem = AsyncStorage.setItem as jest.Mock;
+const mockedRemoveItem = AsyncStorage.removeItem as jest.Mock;
+
+const headers = httpClient.defaults.headers as Record<string, unknown>;
+
+function Consumer() {
+  const { signed, login, logout } = useAuth();
+
+  return (
+    <>
+      <Text>{signed ? 'signed-in' : 'signed-out'}</Text>
+      <Text onPress={() => login('user@example.com', 'secret123')}>
+        login-action
+      </Text>
+      <Text onPress={() => logout()}>logout-action</Text>
+    </>
+  );
+}
+
+function renderAuth() {
+  return render(
+    <AuthProvider>
+      <Consumer />
+    </AuthProvider>,
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    mockedAuthLogin.mockReset();
+    mockedGetItem.mockReset();
+    mockedSetItem.mockReset();
+    mockedRemoveItem.mockReset();
+    delete headers.Authorization;
+  });
+
+  it('starts signed out when no token is stored', async () => {
+    mockedGetItem.mockResolvedValue(null);
+
+    const { getByText } = renderAuth();
+
+    await waitFor(() => expect(getByText('signed-out')).toBeTruthy());
+  });
+
+  it('restores the stored token and sets the Authorization header on mount', async () => {
+    mockedGetItem.mockResolvedValue('stored-token');
+
+    const { getByText } = renderAuth();
+
+    await waitFor(() => expect(getByText('signed-in')).toBeTruthy());
+    expect(headers.Authorization).toBe('Bearer stored-token');
+  });
+
+  it('logs in by persisting the token and setting the Authorization header', async () => {
+    mockedAuthLogin.mockResolvedValue('new-token');
+    mockedGetItem.mockResolvedValue(null);
+
+    const { getByText } = renderAuth();
+    await waitFor(() => expect(getByText('signed-out')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByText('login-action'));
+    });
+
+    expect(mockedAuthLogin).toHaveBeenCalledWith(
+      'user@example.com',
+      'secret123',
+    );
+    expect(mockedSetItem).toHaveBeenCalledWith(
+      '@BacuriLabs:token',
+      'new-token',
+    );
+    expect(headers.Authorization).toBe('Bearer new-token');
+    expect(getByText('signed-in')).toBeTruthy();
+  });
+
+  it('logs out by removing the stored token', async () => {
+    mockedAuthLogin.mockResolvedValue('new-token');
+    mockedGetItem.mockResolvedValue(null);
+
+    const { getByText } = renderAuth();
+    await waitFor(() => expect(getByText('signed-out')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByText('login-action'));
+    });
+    await act(async () => {
+      fireEvent.press(getByText('logout-action'));
+    });
+
+    expect(mockedRemoveItem).toHaveBeenCalledWith('@BacuriLabs:token');
+    expect(getByText('signed-out')).toBeTruthy();
+  });
+});

--- a/src/i18n/locales.test.ts
+++ b/src/i18n/locales.test.ts
@@ -1,0 +1,27 @@
+import en from './locales/en-US/translation.json';
+import pt from './locales/pt-BR/translation.json';
+
+type Translation = Record<string, unknown>;
+
+function flatten(obj: Translation, prefix = ''): Record<string, unknown> {
+  return Object.entries(obj).reduce<Record<string, unknown>>(
+    (acc, [key, value]) => {
+      const fullKey = prefix ? `${prefix}.${key}` : key;
+
+      if (value && typeof value === 'object') {
+        return { ...acc, ...flatten(value as Translation, fullKey) };
+      }
+      return { ...acc, [fullKey]: value };
+    },
+    {},
+  );
+}
+
+describe('i18n locales', () => {
+  it('keeps en-US and pt-BR translation keys in sync', () => {
+    const enKeys = Object.keys(flatten(en as Translation));
+    const ptKeys = Object.keys(flatten(pt as Translation));
+
+    expect(enKeys).toEqual(ptKeys);
+  });
+});

--- a/src/lib/httpClient.test.ts
+++ b/src/lib/httpClient.test.ts
@@ -1,0 +1,7 @@
+import api from './httpClient';
+
+describe('httpClient', () => {
+  it('creates an axios instance with the environment api url', () => {
+    expect(api.defaults.baseURL).toBe('http://localhost:3000');
+  });
+});

--- a/src/pages/AddDependent/index.test.tsx
+++ b/src/pages/AddDependent/index.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import AddDependent from '.';
+
+import { createDependentProfile } from '../../services/user/user.service';
+
+const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
+}));
+
+jest.mock('../../services/user/user.service', () => ({
+  createDependentProfile: jest.fn(),
+}));
+
+const createDependentProfileMock = createDependentProfile as jest.Mock;
+
+describe('AddDependent', () => {
+  beforeEach(() => {
+    mockGoBack.mockReset();
+    mockNavigate.mockReset();
+    createDependentProfileMock.mockReset();
+  });
+
+  it('renders the form fields', () => {
+    const { getByPlaceholderText, getByText } = render(<AddDependent />);
+
+    expect(getByPlaceholderText('addDependent.namePlaceholder')).toBeTruthy();
+    expect(
+      getByPlaceholderText('addDependent.birthDatePlaceholder'),
+    ).toBeTruthy();
+    expect(getByPlaceholderText('addDependent.cpfPlaceholder')).toBeTruthy();
+    expect(getByText('addDependent.createDependent')).toBeTruthy();
+  });
+
+  it('creates the dependent profile with the built payload and navigates back', async () => {
+    createDependentProfileMock.mockResolvedValue({ id: 9 });
+
+    const { getByPlaceholderText, getByText } = render(<AddDependent />);
+
+    fireEvent.changeText(
+      getByPlaceholderText('addDependent.namePlaceholder'),
+      'John Doe',
+    );
+    fireEvent.changeText(
+      getByPlaceholderText('addDependent.birthDatePlaceholder'),
+      '15/01/1990',
+    );
+    fireEvent.changeText(
+      getByPlaceholderText('addDependent.cpfPlaceholder'),
+      '12345678901',
+    );
+
+    fireEvent.press(getByText('addDependent.createDependent'));
+
+    await waitFor(() => expect(createDependentProfileMock).toHaveBeenCalled());
+
+    expect(createDependentProfileMock).toHaveBeenCalledWith({
+      profile: {
+        firstName: 'John',
+        lastName: 'Doe',
+        cic: '12345678901',
+        dateOfBirth: '1990-01-15T00:00:00.000Z',
+        gender: 'MALE',
+        profile: 'PATIENT',
+        image: 'DEFAULT',
+      },
+    });
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a general error when the profile creation fails', async () => {
+    createDependentProfileMock.mockRejectedValue(
+      new Error('profile creation failed'),
+    );
+
+    const { getByPlaceholderText, getByText } = render(<AddDependent />);
+
+    fireEvent.changeText(
+      getByPlaceholderText('addDependent.namePlaceholder'),
+      'John Doe',
+    );
+    fireEvent.changeText(
+      getByPlaceholderText('addDependent.birthDatePlaceholder'),
+      '15/01/1990',
+    );
+    fireEvent.changeText(
+      getByPlaceholderText('addDependent.cpfPlaceholder'),
+      '12345678901',
+    );
+
+    fireEvent.press(getByText('addDependent.createDependent'));
+
+    await waitFor(() =>
+      expect(getByText('profile creation failed')).toBeTruthy(),
+    );
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/ApplyVaccine/index.test.tsx
+++ b/src/pages/ApplyVaccine/index.test.tsx
@@ -1,0 +1,112 @@
+import { Alert } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import ApplyVaccine from '.';
+
+import { applyVaccine } from '../../services/vaccine/vaccine.service';
+
+const mockGoBack = jest.fn();
+const mockUseRoute = jest.fn();
+const mockRequestPermission = jest.fn();
+const alertSpy = jest.spyOn(Alert, 'alert');
+let mockCameraPermission: { granted: boolean } | undefined;
+
+const mockApplyVaccine = applyVaccine as jest.Mock;
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: mockGoBack, navigate: jest.fn() }),
+  useRoute: () => mockUseRoute(),
+}));
+
+jest.mock('../../services/vaccine/vaccine.service', () => ({
+  applyVaccine: jest.fn(),
+}));
+
+jest.mock('expo-camera', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  return {
+    __esModule: true,
+    CameraView: (props: Record<string, unknown>) =>
+      React.createElement(View, { testID: 'camera-view', ...props }),
+    useCameraPermissions: () => [mockCameraPermission, mockRequestPermission],
+  };
+});
+
+describe('ApplyVaccine', () => {
+  beforeEach(() => {
+    mockGoBack.mockReset();
+    mockUseRoute.mockReset();
+    mockRequestPermission.mockReset();
+    mockApplyVaccine.mockReset();
+    alertSpy.mockClear();
+    mockCameraPermission = undefined;
+    mockUseRoute.mockReturnValue({ params: { id: 5 } });
+  });
+
+  it('renders an empty view while the camera permission is loading', () => {
+    const { queryByText } = render(<ApplyVaccine />);
+
+    expect(queryByText('applyVaccine.permissionTitle')).toBeNull();
+  });
+
+  it('shows the permission prompt and requests permission on press', () => {
+    mockCameraPermission = { granted: false };
+
+    const { getByText } = render(<ApplyVaccine />);
+
+    expect(getByText('applyVaccine.permissionTitle')).toBeTruthy();
+    fireEvent.press(getByText('applyVaccine.permissionButton'));
+    expect(mockRequestPermission).toHaveBeenCalled();
+  });
+
+  it('applies the vaccine and shows a success alert when a QR code is scanned', async () => {
+    mockCameraPermission = { granted: true };
+    mockApplyVaccine.mockResolvedValue({ id: 1 });
+
+    const { getByTestId } = render(<ApplyVaccine />);
+
+    fireEvent(getByTestId('camera-view'), 'barcodeScanned', {
+      data: 'SGVsbG8gV29ybGQ=',
+    });
+
+    await waitFor(() => {
+      expect(mockApplyVaccine).toHaveBeenCalledWith(5, 'Hello World');
+      expect(alertSpy).toHaveBeenCalledWith(
+        'applyVaccine.successTitle',
+        'applyVaccine.successMessage',
+      );
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows an error alert when applying the vaccine fails', async () => {
+    mockCameraPermission = { granted: true };
+    mockApplyVaccine.mockRejectedValue(new Error('vaccine application failed'));
+
+    const { getByTestId } = render(<ApplyVaccine />);
+
+    fireEvent(getByTestId('camera-view'), 'barcodeScanned', {
+      data: 'SGVsbG8gV29ybGQ=',
+    });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'applyVaccine.errorTitle',
+        'applyVaccine.errorMessage',
+      );
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('ignores scans without data', () => {
+    mockCameraPermission = { granted: true };
+
+    const { getByTestId } = render(<ApplyVaccine />);
+
+    fireEvent(getByTestId('camera-view'), 'barcodeScanned', { data: null });
+
+    expect(mockApplyVaccine).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/CampaignDetail/index.test.tsx
+++ b/src/pages/CampaignDetail/index.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import CampaignDetail from '.';
+
+import type { Campaign } from '../../@types/models';
+
+const mockNavigate = jest.fn();
+const mockUseRoute = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => mockUseRoute(),
+}));
+
+const campaign: Campaign = {
+  id: 1,
+  title: 'Flu Campaign',
+  description: 'Get your flu shot',
+  image: null,
+  places: [
+    {
+      id: 1,
+      name: 'Clinic A',
+      applied: 3,
+      amount: 10,
+      latitude: 12,
+      longitude: 12,
+    },
+    {
+      id: 2,
+      name: 'Clinic B',
+      applied: 2,
+      amount: 5,
+      latitude: 13,
+      longitude: 13,
+    },
+  ],
+};
+
+describe('CampaignDetail', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockUseRoute.mockReset();
+    mockUseRoute.mockReturnValue({ params: campaign });
+  });
+
+  it('renders the campaign title, description and remaining vaccines', () => {
+    const { getByText } = render(<CampaignDetail />);
+
+    expect(getByText('Flu Campaign')).toBeTruthy();
+    expect(getByText('Get your flu shot')).toBeTruthy();
+    expect(getByText('10')).toBeTruthy();
+    expect(getByText('campaignDetail.remainingVaccines')).toBeTruthy();
+  });
+
+  it('navigates to the campaign map with the places', () => {
+    const { getByText } = render(<CampaignDetail />);
+
+    fireEvent.press(getByText('campaignDetail.viewAvailablePlaces'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('CampaignMap', {
+      places: campaign.places,
+    });
+  });
+});

--- a/src/pages/CampaignMap/index.test.tsx
+++ b/src/pages/CampaignMap/index.test.tsx
@@ -1,0 +1,103 @@
+import { Alert } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+import * as Location from 'expo-location';
+
+import CampaignMap from '.';
+
+const mockUseRoute = jest.fn();
+const alertSpy = jest.spyOn(Alert, 'alert');
+
+jest.mock('@react-navigation/native', () => ({
+  useRoute: () => mockUseRoute(),
+}));
+
+jest.mock('expo-location', () => ({
+  __esModule: true,
+  requestForegroundPermissionsAsync: jest.fn(),
+  getCurrentPositionAsync: jest.fn(),
+}));
+
+jest.mock('react-native-maps', () => {
+  const React = require('react');
+  const { Text, View } = require('react-native');
+
+  const MapView = (props: Record<string, unknown>) =>
+    React.createElement(View, props);
+
+  const Marker = ({ title, children, ...props }: Record<string, unknown>) =>
+    React.createElement(Text, props, title ?? children);
+
+  return {
+    __esModule: true,
+    default: MapView,
+    Marker,
+  };
+});
+
+const mockRequestForegroundPermissionsAsync =
+  Location.requestForegroundPermissionsAsync as jest.Mock;
+const mockGetCurrentPositionAsync =
+  Location.getCurrentPositionAsync as jest.Mock;
+
+const places = [
+  {
+    id: 1,
+    name: 'Place A',
+    applied: 3,
+    amount: 10,
+    latitude: '-23.55',
+    longitude: '-46.63',
+  },
+  {
+    id: 2,
+    name: 'Place B',
+    applied: 1,
+    amount: 5,
+    latitude: '-23.56',
+    longitude: '-46.64',
+  },
+];
+
+describe('CampaignMap', () => {
+  beforeEach(() => {
+    mockUseRoute.mockReset();
+    mockRequestForegroundPermissionsAsync.mockReset();
+    mockGetCurrentPositionAsync.mockReset();
+    alertSpy.mockClear();
+    mockUseRoute.mockReturnValue({ params: { places } });
+  });
+
+  it('alerts when the location permission is denied', async () => {
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({
+      status: 'denied',
+    });
+
+    const { queryByText } = render(<CampaignMap />);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'campaignMap.permissionTitle',
+        'campaignMap.permissionMessage',
+      );
+    });
+
+    expect(mockGetCurrentPositionAsync).not.toHaveBeenCalled();
+    expect(queryByText('Place A')).toBeNull();
+  });
+
+  it('renders the map with markers once the position is available', async () => {
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({
+      status: 'granted',
+    });
+    mockGetCurrentPositionAsync.mockResolvedValue({
+      coords: { latitude: -23.55, longitude: -46.63 },
+    });
+
+    const { getByText, queryByText } = render(<CampaignMap />);
+
+    expect(queryByText('Place A')).toBeNull();
+
+    await waitFor(() => expect(getByText('Place A')).toBeTruthy());
+    expect(getByText('Place B')).toBeTruthy();
+  });
+});

--- a/src/pages/Campaigns/index.test.tsx
+++ b/src/pages/Campaigns/index.test.tsx
@@ -1,0 +1,86 @@
+/* eslint-disable camelcase */
+import { ActivityIndicator } from 'react-native';
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
+
+import Campaigns from '.';
+import { renderWithSWR } from '../../testUtils';
+
+import { getMyCampaigns } from '../../services/campaign/campaign.service';
+
+import type { Campaign } from '../../@types/models';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ params: { id: 42 } }),
+}));
+
+jest.mock('../../services/campaign/campaign.service', () => ({
+  getMyCampaigns: jest.fn(),
+}));
+
+const mockedGetMyCampaigns = getMyCampaigns as jest.Mock;
+
+const campaign: Campaign = {
+  id: 1,
+  title: 'Flu Campaign',
+  description: 'Get your flu shot',
+  image: null,
+  places: [
+    {
+      id: 1,
+      name: 'Clinic A',
+      applied: 2,
+      amount: 6,
+      latitude: 12,
+      longitude: 12,
+    },
+  ],
+};
+
+describe('Campaigns', () => {
+  beforeEach(() => {
+    mockedGetMyCampaigns.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it('shows a loading indicator while fetching', async () => {
+    let resolveCampaigns: ((value: Campaign[]) => void) | undefined;
+    mockedGetMyCampaigns.mockImplementation(
+      () =>
+        new Promise<Campaign[]>((resolve) => {
+          resolveCampaigns = resolve;
+        }),
+    );
+
+    const { UNSAFE_getByType } = renderWithSWR(<Campaigns />);
+
+    expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+
+    await act(async () => {
+      resolveCampaigns?.([]);
+    });
+  });
+
+  it('renders the campaigns once loaded', async () => {
+    mockedGetMyCampaigns.mockResolvedValue([campaign]);
+
+    const { getByText } = renderWithSWR(<Campaigns />);
+
+    await waitFor(() => expect(getByText('Flu Campaign')).toBeTruthy());
+    expect(mockedGetMyCampaigns).toHaveBeenCalledWith(42);
+  });
+
+  it('navigates to the campaign detail on press', async () => {
+    mockedGetMyCampaigns.mockResolvedValue([campaign]);
+
+    const { getByText } = renderWithSWR(<Campaigns />);
+
+    await waitFor(() => expect(getByText('Flu Campaign')).toBeTruthy());
+
+    fireEvent.press(getByText('Flu Campaign'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('CampaignDetail', campaign);
+  });
+});

--- a/src/pages/Dependent/index.test.tsx
+++ b/src/pages/Dependent/index.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import Dependent from '.';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate, setOptions: jest.fn() }),
+  useRoute: () => ({ params: { id: 42, name: 'John Doe' } }),
+}));
+
+describe('Dependent', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('renders the welcome header and the three action cards', () => {
+    const { getByText } = render(<Dependent />);
+
+    expect(getByText('dependent.welcomeTitle')).toBeTruthy();
+    expect(getByText('dependent.applyVaccineTitle')).toBeTruthy();
+    expect(getByText('dependent.myVaccinesTitle')).toBeTruthy();
+    expect(getByText('dependent.campaignsTitle')).toBeTruthy();
+  });
+
+  it('navigates to ApplyVaccine with the profile id', () => {
+    const { getByText } = render(<Dependent />);
+
+    fireEvent.press(getByText('dependent.applyVaccineTitle'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('ApplyVaccine', { id: 42 });
+  });
+
+  it('navigates to MyVaccines with the profile id', () => {
+    const { getByText } = render(<Dependent />);
+
+    fireEvent.press(getByText('dependent.myVaccinesTitle'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('MyVaccines', { id: 42 });
+  });
+
+  it('navigates to Campaigns with the profile id', () => {
+    const { getByText } = render(<Dependent />);
+
+    fireEvent.press(getByText('dependent.campaignsTitle'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('Campaigns', { id: 42 });
+  });
+});

--- a/src/pages/Login/index.test.tsx
+++ b/src/pages/Login/index.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import Login from '.';
+
+const mockLogin = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('../../contexts/auth', () => ({
+  useAuth: () => ({ login: mockLogin, signed: false }),
+}));
+
+describe('Login', () => {
+  beforeEach(() => {
+    mockLogin.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it('renders the email, password and submit button', () => {
+    const { getByPlaceholderText, getByText } = render(<Login />);
+
+    expect(getByPlaceholderText('login.emailPlaceholder')).toBeTruthy();
+    expect(getByPlaceholderText('login.passwordPlaceholder')).toBeTruthy();
+    expect(getByText('login.submit')).toBeTruthy();
+  });
+
+  it('does not submit while the form is invalid', async () => {
+    const { getByText } = render(<Login />);
+
+    fireEvent.press(getByText('login.submit'));
+
+    await waitFor(() => expect(mockLogin).not.toHaveBeenCalled());
+  });
+
+  it('shows a validation error for an invalid email after blur', async () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(<Login />);
+
+    const emailInput = getByPlaceholderText('login.emailPlaceholder');
+
+    fireEvent.changeText(emailInput, 'not-an-email');
+    fireEvent(emailInput, 'blur');
+
+    await waitFor(() =>
+      expect(getByText('validation.emailInvalid')).toBeTruthy(),
+    );
+    expect(queryByText('validation.emailRequired')).toBeNull();
+  });
+
+  it('shows a validation error for a short password after blur', async () => {
+    const { getByPlaceholderText, getByText } = render(<Login />);
+
+    const passwordInput = getByPlaceholderText('login.passwordPlaceholder');
+
+    fireEvent.changeText(passwordInput, '123');
+    fireEvent(passwordInput, 'blur');
+
+    await waitFor(() =>
+      expect(getByText('validation.passwordMin')).toBeTruthy(),
+    );
+  });
+
+  it('submits the credentials on a valid form', async () => {
+    mockLogin.mockResolvedValue(undefined);
+
+    const { getByPlaceholderText, getByText } = render(<Login />);
+
+    fireEvent.changeText(
+      getByPlaceholderText('login.emailPlaceholder'),
+      'user@example.com',
+    );
+    fireEvent.changeText(
+      getByPlaceholderText('login.passwordPlaceholder'),
+      'secret123',
+    );
+
+    fireEvent.press(getByText('login.submit'));
+
+    await waitFor(() =>
+      expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'secret123'),
+    );
+  });
+
+  it('shows the invalid credentials error when login rejects with invalid_grant', async () => {
+    mockLogin.mockRejectedValue({
+      response: { data: { error: 'invalid_grant' } },
+    });
+
+    const { getByPlaceholderText, getByText } = render(<Login />);
+
+    fireEvent.changeText(
+      getByPlaceholderText('login.emailPlaceholder'),
+      'user@example.com',
+    );
+    fireEvent.changeText(
+      getByPlaceholderText('login.passwordPlaceholder'),
+      'secret123',
+    );
+
+    fireEvent.press(getByText('login.submit'));
+
+    await waitFor(() =>
+      expect(getByText('validation.invalidCredentials')).toBeTruthy(),
+    );
+  });
+});

--- a/src/pages/Login/index.test.tsx
+++ b/src/pages/Login/index.test.tsx
@@ -83,6 +83,33 @@ describe('Login', () => {
     );
   });
 
+  it('submits the credentials when the password field is submitted', async () => {
+    mockLogin.mockResolvedValue(undefined);
+
+    const { getByPlaceholderText } = render(<Login />);
+
+    fireEvent.changeText(
+      getByPlaceholderText('login.emailPlaceholder'),
+      'user@example.com',
+    );
+    const passwordInput = getByPlaceholderText('login.passwordPlaceholder');
+    fireEvent.changeText(passwordInput, 'secret123');
+
+    fireEvent(passwordInput, 'submitEditing');
+
+    await waitFor(() =>
+      expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'secret123'),
+    );
+  });
+
+  it('navigates to the sign up page when the create account link is pressed', () => {
+    const { getByText } = render(<Login />);
+
+    fireEvent.press(getByText('login.createAccountNow'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('SignUp');
+  });
+
   it('shows the invalid credentials error when login rejects with invalid_grant', async () => {
     mockLogin.mockRejectedValue({
       response: { data: { error: 'invalid_grant' } },

--- a/src/pages/MyVaccines/index.test.tsx
+++ b/src/pages/MyVaccines/index.test.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable camelcase */
+import { ActivityIndicator } from 'react-native';
+import { act, waitFor } from '@testing-library/react-native';
+
+import MyVaccines from '.';
+import { renderWithSWR } from '../../testUtils';
+
+import { getVaccineTimeline } from '../../services/vaccine/vaccine.service';
+
+import type { VaccineTimelineItem } from '../../@types/models';
+
+jest.mock('@react-navigation/native', () => ({
+  useRoute: () => ({ params: { id: 42 } }),
+}));
+
+jest.mock('../../services/vaccine/vaccine.service', () => ({
+  getVaccineTimeline: jest.fn(),
+}));
+
+const mockedGetVaccineTimeline = getVaccineTimeline as jest.Mock;
+
+const timelineItem = {
+  vaccine: {
+    name: 'BCG',
+    preventedDiseases: 'tuberculosis',
+    initialRange: 0,
+    finalRange: 0,
+    observation: '',
+    dosage: 'DOSAGE_UNIQUE',
+    range: 'INFANT',
+    requirement: null,
+    nextVaccine: null,
+  },
+  applied: true,
+} as VaccineTimelineItem;
+
+describe('MyVaccines', () => {
+  beforeEach(() => {
+    mockedGetVaccineTimeline.mockReset();
+  });
+
+  it('shows a loading indicator while fetching', async () => {
+    let resolveTimeline: ((value: VaccineTimelineItem[]) => void) | undefined;
+    mockedGetVaccineTimeline.mockImplementation(
+      () =>
+        new Promise<VaccineTimelineItem[]>((resolve) => {
+          resolveTimeline = resolve;
+        }),
+    );
+
+    const { UNSAFE_getByType } = renderWithSWR(<MyVaccines />);
+
+    expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+
+    await act(async () => {
+      resolveTimeline?.([]);
+    });
+  });
+
+  it('renders the vaccine cards once loaded', async () => {
+    mockedGetVaccineTimeline.mockResolvedValue([timelineItem]);
+
+    const { getByText } = renderWithSWR(<MyVaccines />);
+
+    await waitFor(() => expect(getByText('BCG')).toBeTruthy());
+    expect(mockedGetVaccineTimeline).toHaveBeenCalledWith(42);
+  });
+
+  it('shows an error message when the fetch fails', async () => {
+    mockedGetVaccineTimeline.mockRejectedValue(new Error('network error'));
+
+    const { getByText } = renderWithSWR(<MyVaccines />);
+
+    await waitFor(() =>
+      expect(getByText('myVaccines.errorMessage')).toBeTruthy(),
+    );
+  });
+});

--- a/src/pages/ProfileList/index.test.tsx
+++ b/src/pages/ProfileList/index.test.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable camelcase */
+import { ActivityIndicator } from 'react-native';
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
+
+import ProfileList, { createRows } from '.';
+import { renderWithSWR } from '../../testUtils';
+
+import { getUser } from '../../services/user/user.service';
+import type { UserResponse } from '../../services/user/user.service';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+  useIsFocused: () => true,
+}));
+
+jest.mock('../../services/user/user.service', () => ({
+  getUser: jest.fn(),
+}));
+
+jest.mock('../../contexts/auth', () => ({
+  useAuth: () => ({ logout: jest.fn(), signed: true }),
+}));
+
+const mockedGetUser = getUser as jest.Mock;
+
+describe('createRows', () => {
+  it('keeps a full last row as-is', () => {
+    const rows = createRows([{ id: 1 }, { id: 2 }, { addButton: true }], 3);
+
+    expect(rows).toEqual([{ id: 1 }, { id: 2 }, { addButton: true }]);
+  });
+
+  it('pads the last row with empty placeholders', () => {
+    const rows = createRows([{ id: 1 }, { addButton: true }], 3);
+
+    expect(rows).toEqual([
+      { id: 1 },
+      { addButton: true },
+      { id: 'empty-2', name: 'empty-2', empty: true },
+    ]);
+  });
+
+  it('fills a grid that only contains the add button', () => {
+    const rows = createRows([{ addButton: true }], 3);
+
+    expect(rows).toHaveLength(3);
+    expect(rows).toEqual([
+      { addButton: true },
+      { id: 'empty-1', name: 'empty-1', empty: true },
+      { id: 'empty-2', name: 'empty-2', empty: true },
+    ]);
+  });
+});
+
+describe('ProfileList', () => {
+  beforeEach(() => {
+    mockedGetUser.mockReset();
+  });
+
+  it('shows a loading indicator while fetching', async () => {
+    let resolveUser: ((value: UserResponse) => void) | undefined;
+    mockedGetUser.mockImplementation(
+      () =>
+        new Promise<UserResponse>((resolve) => {
+          resolveUser = resolve;
+        }),
+    );
+
+    const { UNSAFE_getByType } = renderWithSWR(<ProfileList />);
+
+    expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+
+    await act(async () => {
+      resolveUser?.({ content: { dependentProfiles: [] } });
+    });
+  });
+
+  it('renders the dependent profiles once loaded', async () => {
+    mockedGetUser.mockResolvedValue({
+      content: {
+        dependentProfiles: [{ id: 1, firstName: 'John', lastName: 'Doe' }],
+      },
+    });
+
+    const { getByText } = renderWithSWR(<ProfileList />);
+
+    await waitFor(() => expect(getByText('John Doe')).toBeTruthy());
+  });
+
+  it('shows an error page and reloads on retry', async () => {
+    mockedGetUser.mockRejectedValue(new Error('network error'));
+
+    const { getByText } = renderWithSWR(<ProfileList />);
+
+    await waitFor(() =>
+      expect(getByText('profileList.reloadButton')).toBeTruthy(),
+    );
+
+    mockedGetUser.mockResolvedValue({
+      content: {
+        dependentProfiles: [{ id: 1, firstName: 'John', lastName: 'Doe' }],
+      },
+    });
+
+    fireEvent.press(getByText('profileList.reloadButton'));
+
+    await waitFor(() => expect(getByText('John Doe')).toBeTruthy());
+  });
+});

--- a/src/pages/ProfileList/index.test.tsx
+++ b/src/pages/ProfileList/index.test.tsx
@@ -8,8 +8,10 @@ import { renderWithSWR } from '../../testUtils';
 import { getUser } from '../../services/user/user.service';
 import type { UserResponse } from '../../services/user/user.service';
 
+const mockNavigate = jest.fn();
+
 jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ navigate: jest.fn() }),
+  useNavigation: () => ({ navigate: mockNavigate }),
   useIsFocused: () => true,
 }));
 
@@ -55,6 +57,7 @@ describe('createRows', () => {
 describe('ProfileList', () => {
   beforeEach(() => {
     mockedGetUser.mockReset();
+    mockNavigate.mockReset();
   });
 
   it('shows a loading indicator while fetching', async () => {
@@ -105,5 +108,42 @@ describe('ProfileList', () => {
     fireEvent.press(getByText('profileList.reloadButton'));
 
     await waitFor(() => expect(getByText('John Doe')).toBeTruthy());
+  });
+
+  it('navigates to the dependent page when a profile card is pressed', async () => {
+    mockedGetUser.mockResolvedValue({
+      content: {
+        dependentProfiles: [{ id: 1, firstName: 'John', lastName: 'Doe' }],
+      },
+    });
+
+    const { getByText } = renderWithSWR(<ProfileList />);
+
+    await waitFor(() => expect(getByText('John Doe')).toBeTruthy());
+
+    fireEvent.press(getByText('John Doe'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('Dependent', {
+      id: 1,
+      name: 'John Doe',
+    });
+  });
+
+  it('navigates to the add dependent page when the add card is pressed', async () => {
+    mockedGetUser.mockResolvedValue({
+      content: {
+        dependentProfiles: [],
+      },
+    });
+
+    const { getByText } = renderWithSWR(<ProfileList />);
+
+    await waitFor(() =>
+      expect(getByText('profileList.selectProfile')).toBeTruthy(),
+    );
+
+    fireEvent.press(getByText('FontAwesome5'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('AddDependent');
   });
 });

--- a/src/pages/ProfileList/index.tsx
+++ b/src/pages/ProfileList/index.tsx
@@ -66,11 +66,11 @@ function LogoutButton() {
   );
 }
 
-function createRows(items: ProfileCardItem[], columns: number) {
+export function createRows(items: ProfileCardItem[], columns: number) {
   const rows = Math.floor(items.length / columns);
   let lastRowElements = items.length - rows * columns;
 
-  while (lastRowElements !== columns) {
+  while (lastRowElements !== columns && lastRowElements !== 0) {
     items.push({
       id: `empty-${lastRowElements}`,
       name: `empty-${lastRowElements}`,

--- a/src/pages/SignUp/index.test.tsx
+++ b/src/pages/SignUp/index.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import SignUp from '.';
+
+import { register } from '../../services/auth/auth.service';
+
+const mockLogin = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: mockGoBack, navigate: jest.fn() }),
+}));
+
+jest.mock('../../contexts/auth', () => ({
+  useAuth: () => ({ login: mockLogin, signed: false }),
+}));
+
+jest.mock('../../services/auth/auth.service', () => ({
+  register: jest.fn(),
+}));
+
+const registerMock = register as jest.Mock;
+
+function fillSignUpForm(getByPlaceholderText: (text: string) => any) {
+  fireEvent.changeText(
+    getByPlaceholderText('signup.namePlaceholder'),
+    'John Doe',
+  );
+  fireEvent.changeText(
+    getByPlaceholderText('signup.emailPlaceholder'),
+    'user@example.com',
+  );
+  fireEvent.changeText(
+    getByPlaceholderText('signup.birthDatePlaceholder'),
+    '15/01/1990',
+  );
+  fireEvent.changeText(
+    getByPlaceholderText('signup.cpfPlaceholder'),
+    '12345678901',
+  );
+  fireEvent.changeText(
+    getByPlaceholderText('signup.passwordPlaceholder'),
+    'secret123',
+  );
+  fireEvent.changeText(
+    getByPlaceholderText('signup.confirmPasswordPlaceholder'),
+    'secret123',
+  );
+}
+
+describe('SignUp', () => {
+  beforeEach(() => {
+    mockLogin.mockReset();
+    mockGoBack.mockReset();
+    registerMock.mockReset();
+  });
+
+  it('renders all the form fields', () => {
+    const { getByPlaceholderText } = render(<SignUp />);
+
+    expect(getByPlaceholderText('signup.namePlaceholder')).toBeTruthy();
+    expect(getByPlaceholderText('signup.emailPlaceholder')).toBeTruthy();
+    expect(getByPlaceholderText('signup.birthDatePlaceholder')).toBeTruthy();
+    expect(getByPlaceholderText('signup.cpfPlaceholder')).toBeTruthy();
+    expect(getByPlaceholderText('signup.passwordPlaceholder')).toBeTruthy();
+    expect(
+      getByPlaceholderText('signup.confirmPasswordPlaceholder'),
+    ).toBeTruthy();
+  });
+
+  it('shows a validation error when the passwords do not match', async () => {
+    const { getByPlaceholderText, getByText } = render(<SignUp />);
+
+    fireEvent.changeText(
+      getByPlaceholderText('signup.passwordPlaceholder'),
+      'secret123',
+    );
+    const confirmInput = getByPlaceholderText(
+      'signup.confirmPasswordPlaceholder',
+    );
+    fireEvent.changeText(confirmInput, 'secret124');
+    fireEvent(confirmInput, 'blur');
+
+    await waitFor(() =>
+      expect(getByText('validation.passwordsMustMatch')).toBeTruthy(),
+    );
+  });
+
+  it('registers the user and logs in with the built payload', async () => {
+    registerMock.mockResolvedValue({ id: 1 });
+    mockLogin.mockResolvedValue(undefined);
+
+    const { getByPlaceholderText, getByText } = render(<SignUp />);
+
+    fillSignUpForm(getByPlaceholderText);
+    fireEvent.press(getByText('signup.createAccount'));
+
+    await waitFor(() => expect(registerMock).toHaveBeenCalled());
+
+    expect(registerMock).toHaveBeenCalledWith({
+      platform: 'APP',
+      role: 'DEFAULT',
+      user: {
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'user@example.com',
+        dateOfBirth: '1990-01-15T00:00:00.000Z',
+        cic: '12345678901',
+        gender: 'MALE',
+        password: 'secret123',
+      },
+    });
+    expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'secret123');
+  });
+
+  it('shows a general error when registration fails', async () => {
+    registerMock.mockRejectedValue(new Error('registration failed'));
+
+    const { getByPlaceholderText, getByText } = render(<SignUp />);
+
+    fillSignUpForm(getByPlaceholderText);
+    fireEvent.press(getByText('signup.createAccount'));
+
+    await waitFor(() => expect(getByText('registration failed')).toBeTruthy());
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/SignInStack.test.tsx
+++ b/src/routes/SignInStack.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react-native';
+
+import SignInStack from './SignInStack';
+
+jest.mock('@react-navigation/stack', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  const Navigator = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(View, null, children);
+
+  const Screen = ({ name }: { name: string }) =>
+    React.createElement(View, { testID: `screen-${name}` });
+
+  return {
+    __esModule: true,
+    createStackNavigator: () => ({ Navigator, Screen }),
+  };
+});
+
+describe('SignInStack', () => {
+  it('registers all the sign-in screens with translated headers', () => {
+    const { getByTestId } = render(<SignInStack />);
+
+    expect(getByTestId('screen-ProfileList')).toBeTruthy();
+    expect(getByTestId('screen-Dependent')).toBeTruthy();
+    expect(getByTestId('screen-MyVaccines')).toBeTruthy();
+    expect(getByTestId('screen-AddDependent')).toBeTruthy();
+    expect(getByTestId('screen-ApplyVaccine')).toBeTruthy();
+    expect(getByTestId('screen-Campaigns')).toBeTruthy();
+    expect(getByTestId('screen-CampaignDetail')).toBeTruthy();
+    expect(getByTestId('screen-CampaignMap')).toBeTruthy();
+  });
+});

--- a/src/routes/SignOutStack.test.tsx
+++ b/src/routes/SignOutStack.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react-native';
+
+import SignOutStack from './SignOutStack';
+
+jest.mock('@react-navigation/stack', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  const Navigator = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(View, null, children);
+
+  const Screen = ({ name }: { name: string }) =>
+    React.createElement(View, { testID: `screen-${name}` });
+
+  return {
+    __esModule: true,
+    createStackNavigator: () => ({ Navigator, Screen }),
+  };
+});
+
+describe('SignOutStack', () => {
+  it('registers the login and sign-up screens', () => {
+    const { getByTestId } = render(<SignOutStack />);
+
+    expect(getByTestId('screen-Login')).toBeTruthy();
+    expect(getByTestId('screen-SignUp')).toBeTruthy();
+  });
+});

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react-native';
+
+import Routes from '.';
+
+const mockSigned = { current: false };
+
+jest.mock('../contexts/auth', () => ({
+  useAuth: () => ({ signed: mockSigned.current }),
+}));
+
+jest.mock('./SignOutStack', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  return function MockSignOutStack() {
+    return React.createElement(Text, null, 'SignOutStack');
+  };
+});
+
+jest.mock('./SignInStack', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  return function MockSignInStack() {
+    return React.createElement(Text, null, 'SignInStack');
+  };
+});
+
+describe('Routes', () => {
+  it('renders the sign-out stack when the user is signed out', () => {
+    mockSigned.current = false;
+
+    const { getByText } = render(<Routes />);
+
+    expect(getByText('SignOutStack')).toBeTruthy();
+  });
+
+  it('renders the sign-in stack when the user is signed in', () => {
+    mockSigned.current = true;
+
+    const { getByText } = render(<Routes />);
+
+    expect(getByText('SignInStack')).toBeTruthy();
+  });
+});

--- a/src/services/auth/auth.service.test.ts
+++ b/src/services/auth/auth.service.test.ts
@@ -1,0 +1,55 @@
+import { encode } from 'base-64';
+
+import httpClient from '../../lib/httpClient';
+import { login, register } from './auth.service';
+
+jest.mock('../../lib/httpClient', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+    get: jest.fn(),
+  },
+}));
+
+const mockPost = httpClient.post as jest.Mock;
+
+describe('auth.service', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+  });
+
+  describe('login', () => {
+    it('posts credentials to /oauth/token with Basic authorization and returns the access token', async () => {
+      mockPost.mockResolvedValue({ data: { access_token: 'token-123' } });
+
+      const token = await login('user@example.com', 'secret123');
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/oauth/token',
+        {
+          grant_type: 'password',
+          username: 'user@example.com',
+          password: 'secret123',
+        },
+        {
+          headers: {
+            Authorization: `Basic ${encode('test-client:test-secret')}`,
+          },
+        },
+      );
+      expect(token).toBe('token-123');
+    });
+  });
+
+  describe('register', () => {
+    it('posts user data to /register and returns the response body', async () => {
+      mockPost.mockResolvedValue({ data: { id: 1 } });
+      const userData = { platform: 'APP', role: 'DEFAULT' };
+
+      const result = await register(userData);
+
+      expect(mockPost).toHaveBeenCalledWith('/register', userData);
+      expect(result).toEqual({ id: 1 });
+    });
+  });
+});

--- a/src/services/campaign/campaign.service.test.ts
+++ b/src/services/campaign/campaign.service.test.ts
@@ -1,0 +1,30 @@
+import httpClient from '../../lib/httpClient';
+import { getMyCampaigns } from './campaign.service';
+
+import type { Campaign } from '../../@types/models';
+
+jest.mock('../../lib/httpClient', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+    get: jest.fn(),
+  },
+}));
+
+const mockGet = httpClient.get as jest.Mock;
+
+describe('campaign.service', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('getMyCampaigns fetches the campaigns for a profile and unwraps content', async () => {
+    const content = [{ id: 1, title: 'Campaign 1' }] as Campaign[];
+    mockGet.mockResolvedValue({ data: { content } });
+
+    const result = await getMyCampaigns(42);
+
+    expect(mockGet).toHaveBeenCalledWith('/campaign/my-campaigns?profileId=42');
+    expect(result).toEqual(content);
+  });
+});

--- a/src/services/user/user.service.test.ts
+++ b/src/services/user/user.service.test.ts
@@ -1,0 +1,44 @@
+import httpClient from '../../lib/httpClient';
+import { getUser, createDependentProfile } from './user.service';
+
+jest.mock('../../lib/httpClient', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+    get: jest.fn(),
+  },
+}));
+
+const mockGet = httpClient.get as jest.Mock;
+const mockPost = httpClient.post as jest.Mock;
+
+describe('user.service', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+  });
+
+  it('getUser fetches /user', async () => {
+    const response = {
+      content: {
+        dependentProfiles: [{ id: 1, firstName: 'John', lastName: 'Doe' }],
+      },
+    };
+    mockGet.mockResolvedValue({ data: response });
+
+    const result = await getUser();
+
+    expect(mockGet).toHaveBeenCalledWith('/user');
+    expect(result).toEqual(response);
+  });
+
+  it('createDependentProfile posts the profile data to /dependent-profile', async () => {
+    mockPost.mockResolvedValue({ data: { id: 9 } });
+    const profileData = { profile: { firstName: 'Jane' } };
+
+    const result = await createDependentProfile(profileData);
+
+    expect(mockPost).toHaveBeenCalledWith('/dependent-profile', profileData);
+    expect(result).toEqual({ id: 9 });
+  });
+});

--- a/src/services/vaccine/vaccine.service.test.ts
+++ b/src/services/vaccine/vaccine.service.test.ts
@@ -1,0 +1,45 @@
+import httpClient from '../../lib/httpClient';
+import { getVaccineTimeline, applyVaccine } from './vaccine.service';
+
+import type { VaccineTimelineItem } from '../../@types/models';
+
+jest.mock('../../lib/httpClient', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+    get: jest.fn(),
+  },
+}));
+
+const mockGet = httpClient.get as jest.Mock;
+const mockPost = httpClient.post as jest.Mock;
+
+describe('vaccine.service', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+  });
+
+  it('getVaccineTimeline fetches the timeline for a profile and unwraps content', async () => {
+    const content = [{ vaccine: {} }] as VaccineTimelineItem[];
+    mockGet.mockResolvedValue({ data: { content } });
+
+    const result = await getVaccineTimeline(42);
+
+    expect(mockGet).toHaveBeenCalledWith('/vaccine/timeline?profileId=42');
+    expect(result).toEqual(content);
+  });
+
+  it('applyVaccine posts the QR data to the apply endpoint', async () => {
+    mockPost.mockResolvedValue({ data: { ok: true } });
+    const qrData = 'encoded-qr';
+
+    const result = await applyVaccine(7, qrData);
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/vaccine/apply?profileId=7&encoded-qr',
+      qrData,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -1,0 +1,18 @@
+import { SWRConfig } from 'swr';
+import { render } from '@testing-library/react-native';
+import type { ReactElement } from 'react';
+
+export function renderWithSWR(ui: ReactElement) {
+  return render(
+    <SWRConfig
+      value={{
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        loadingTimeout: 0,
+        shouldRetryOnError: false,
+      }}
+    >
+      {ui}
+    </SWRConfig>,
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "bundler",
-    "types": [],
+    "types": ["@types/jest"],
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,10 +31,24 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.27.2", "@babel/compat-data@^7.27.7":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.0.tgz#9fc6fd58c2a6a15243cd13983224968392070790"
   integrity sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==
+
+"@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
 
 "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.20.0", "@babel/core@^7.21.3", "@babel/core@^7.25.2", "@babel/core@^7.26.0":
   version "7.28.0"
@@ -51,6 +65,27 @@
     "@babel/template" "^7.27.2"
     "@babel/traverse" "^7.28.0"
     "@babel/types" "^7.28.0"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/core@^7.23.9":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/remapping" "^2.3.5"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -79,6 +114,17 @@
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
+"@babel/generator@^7.29.7", "@babel/generator@^7.29.8", "@babel/generator@^7.7.2":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.8.tgz#4b0b887885422643339e09022148a4c4ebaa4979"
+  integrity sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==
+  dependencies:
+    "@babel/parser" "^7.29.8"
+    "@babel/types" "^7.29.8"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
 "@babel/helper-annotate-as-pure@^7.27.1", "@babel/helper-annotate-as-pure@^7.27.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz#f31fd86b915fc4daf1f3ac6976c59be7084ed9c5"
@@ -93,6 +139,17 @@
   dependencies:
     "@babel/compat-data" "^7.27.2"
     "@babel/helper-validator-option" "^7.27.1"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
+  dependencies:
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
@@ -148,6 +205,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
   integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
 
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
+
 "@babel/helper-member-expression-to-functions@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz#ea1211276be93e798ce19037da6f06fbb994fa44"
@@ -172,6 +234,14 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
+"@babel/helper-module-imports@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
+  integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.27.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz#db0bbcfba5802f9ef7870705a7ef8788508ede02"
@@ -180,6 +250,15 @@
     "@babel/helper-module-imports" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
     "@babel/traverse" "^7.27.3"
+
+"@babel/helper-module-transforms@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz#b062747a5997ba138637201328bbff77960574ae"
+  integrity sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
 "@babel/helper-optimise-call-expression@^7.27.1":
   version "7.27.1"
@@ -197,6 +276,11 @@
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
+
+"@babel/helper-plugin-utils@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz#c0a0766f1a13617d8a17407d7ab8f9d486225ea4"
+  integrity sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==
 
 "@babel/helper-remap-async-to-generator@^7.27.1":
   version "7.27.1"
@@ -229,6 +313,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
@@ -244,10 +333,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
+
 "@babel/helper-validator-option@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
   integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
+
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
 
 "@babel/helper-wrap-function@^7.27.1":
   version "7.27.1"
@@ -266,6 +365,14 @@
     "@babel/template" "^7.27.2"
     "@babel/types" "^7.27.6"
 
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
+  dependencies:
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/highlight@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
@@ -281,6 +388,13 @@
   integrity sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==
   dependencies:
     "@babel/types" "^7.28.0"
+
+"@babel/parser@^7.23.9", "@babel/parser@^7.29.7", "@babel/parser@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
+  integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
+  dependencies:
+    "@babel/types" "^7.29.8"
 
 "@babel/parser@^7.28.5":
   version "7.28.5"
@@ -396,6 +510,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-syntax-jsx@^7.7.2":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
+  integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
@@ -458,6 +579,13 @@
   integrity sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-syntax-typescript@^7.7.2":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
+  integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-transform-arrow-functions@^7.0.0-0", "@babel/plugin-transform-arrow-functions@^7.24.7":
   version "7.27.1"
@@ -859,6 +987,15 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
+"@babel/template@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.0.tgz#518aa113359b062042379e333db18380b537e34b"
@@ -898,6 +1035,19 @@
     "@babel/types" "^7.28.5"
     debug "^4.3.1"
 
+"@babel/traverse@^7.29.7":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.8.tgz#4111014cdc71a0f95d9471907590baa0b8a6b28a"
+  integrity sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.8"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.8"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.8"
+    debug "^4.3.1"
+
 "@babel/types@^7.0.0":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.7.tgz#6039ff1e242640a29452c9ae572162ec9a8f5d13"
@@ -922,6 +1072,19 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@babel/types@^7.29.7", "@babel/types@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
+  integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@egjs/hammerjs@^2.0.17":
   version "2.0.17"
@@ -1372,12 +1535,68 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jest/create-cache-key-function@^29.7.0":
+"@istanbuljs/schema@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
+  integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
+"@jest/console@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc"
+  integrity sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    slash "^3.0.0"
+
+"@jest/core@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.7.0.tgz#b6cccc239f30ff36609658c5a5e2291757ce448f"
+  integrity sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==
+  dependencies:
+    "@jest/console" "^29.7.0"
+    "@jest/reporters" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    jest-changed-files "^29.7.0"
+    jest-config "^29.7.0"
+    jest-haste-map "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-resolve-dependencies "^29.7.0"
+    jest-runner "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    jest-watcher "^29.7.0"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
+
+"@jest/create-cache-key-function@^29.2.1", "@jest/create-cache-key-function@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz#793be38148fab78e65f40ae30c36785f4ad859f0"
   integrity sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==
   dependencies:
     "@jest/types" "^29.6.3"
+
+"@jest/diff-sequences@30.4.0":
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz#8be2d260e6241d6cddddd102c304fe13b4fc8e3e"
+  integrity sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==
 
 "@jest/environment@^29.7.0":
   version "29.7.0"
@@ -1388,6 +1607,21 @@
     "@jest/types" "^29.6.3"
     "@types/node" "*"
     jest-mock "^29.7.0"
+
+"@jest/expect-utils@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
+  integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
+  dependencies:
+    jest-get-type "^29.6.3"
+
+"@jest/expect@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.7.0.tgz#76a3edb0cb753b70dfbfe23283510d3d45432bf2"
+  integrity sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==
+  dependencies:
+    expect "^29.7.0"
+    jest-snapshot "^29.7.0"
 
 "@jest/fake-timers@^29.7.0":
   version "29.7.0"
@@ -1401,12 +1635,93 @@
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
+"@jest/get-type@30.1.0":
+  version "30.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/get-type/-/get-type-30.1.0.tgz#4fcb4dc2ebcf0811be1c04fd1cb79c2dba431cbc"
+  integrity sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==
+
+"@jest/globals@^29.2.1", "@jest/globals@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.7.0.tgz#8d9290f9ec47ff772607fa864ca1d5a2efae1d4d"
+  integrity sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/expect" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    jest-mock "^29.7.0"
+
+"@jest/reporters@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.7.0.tgz#04b262ecb3b8faa83b0b3d321623972393e8f4c7"
+  integrity sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@jridgewell/trace-mapping" "^0.3.18"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^6.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.1.3"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    jest-worker "^29.7.0"
+    slash "^3.0.0"
+    string-length "^4.0.1"
+    strip-ansi "^6.0.0"
+    v8-to-istanbul "^9.0.1"
+
+"@jest/schemas@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-30.4.1.tgz#c3703fdd71357e2c83aa59bd38469e60a11529c6"
+  integrity sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
+
 "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
   integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
   dependencies:
     "@sinclair/typebox" "^0.27.8"
+
+"@jest/source-map@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.6.3.tgz#d90ba772095cf37a34a5eb9413f1b562a08554c4"
+  integrity sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.18"
+    callsites "^3.0.0"
+    graceful-fs "^4.2.9"
+
+"@jest/test-result@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.7.0.tgz#8db9a80aa1a097bb2262572686734baed9b1657c"
+  integrity sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==
+  dependencies:
+    "@jest/console" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
+"@jest/test-sequencer@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz#6cef977ce1d39834a3aea887a1726628a6f072ce"
+  integrity sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==
+  dependencies:
+    "@jest/test-result" "^29.7.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    slash "^3.0.0"
 
 "@jest/transform@^29.7.0":
   version "29.7.0"
@@ -1449,6 +1764,14 @@
     "@jridgewell/sourcemap-codec" "^1.5.0"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@jridgewell/remapping@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
@@ -1466,6 +1789,14 @@
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz#7358043433b2e5da569aa02cbc4c121da3af27d7"
   integrity sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==
+
+"@jridgewell/trace-mapping@^0.3.12":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.29"
@@ -1707,6 +2038,11 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
+"@sinclair/typebox@^0.34.0":
+  version "0.34.52"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.52.tgz#62f8a686e4ab28a8944902e2ad2d648312ef11cb"
+  integrity sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==
+
 "@sinonjs/commons@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
@@ -1818,6 +2154,21 @@
     deepmerge "^4.3.1"
     svgo "^3.0.2"
 
+"@testing-library/react-native@^13":
+  version "13.3.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-13.3.3.tgz#4bf02911c4e18075df40b5de0e029c209fb45bda"
+  integrity sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==
+  dependencies:
+    jest-matcher-utils "^30.0.5"
+    picocolors "^1.1.1"
+    pretty-format "^30.0.5"
+    redent "^3.0.0"
+
+"@tootallnate/once@2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.1.tgz#35adc6222e3662fa2222ce123b961476a746b9ea"
+  integrity sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -1878,6 +2229,11 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
   integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
 
+"@types/istanbul-lib-coverage@^2.0.1":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
+  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
+
 "@types/istanbul-lib-report@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
@@ -1891,6 +2247,23 @@
   integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@^29":
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
+"@types/jsdom@^20.0.0":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-20.0.1.tgz#07c14bc19bd2f918c1929541cdaacae894744808"
+  integrity sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    parse5 "^7.0.0"
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -1925,6 +2298,11 @@
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.5.tgz#1daa6456f40959d06157698a653a9ab0a70281df"
   integrity sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==
+
+"@types/tough-cookie@*":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -2065,6 +2443,11 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
+abab@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -2080,20 +2463,42 @@ accepts@^1.3.7, accepts@^1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+acorn-globals@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-7.0.1.tgz#0dbf05c44fa7c94332914c02066d5beff62c40c3"
+  integrity sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==
+  dependencies:
+    acorn "^8.1.0"
+    acorn-walk "^8.0.2"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn-walk@^8.0.2:
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
+  integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
+  dependencies:
+    acorn "^8.11.0"
+
+acorn@^8.1.0, acorn@^8.11.0, acorn@^8.8.1, acorn@^8.9.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
+  integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
 
 acorn@^8.14.0:
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
-acorn@^8.9.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
-  integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 agent-base@^7.1.2:
   version "7.1.3"
@@ -2115,12 +2520,17 @@ anser@^1.4.9:
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.10.tgz#befa3eddf282684bd03b63dcda3927aef8c2e35b"
   integrity sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   dependencies:
     type-fest "^0.21.3"
+
+ansi-escapes@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-6.2.1.tgz#76c54ce9b081dad39acec4b5d53377913825fb0f"
+  integrity sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==
 
 ansi-regex@^4.1.0:
   version "4.1.0"
@@ -2137,6 +2547,11 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.2.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.3.0.tgz#247c8e7b70a1a43b10ce14c0226fcbf58e8815d5"
+  integrity sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -2151,7 +2566,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^5.0.0:
+ansi-styles@^5.0.0, ansi-styles@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
@@ -2318,6 +2733,11 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -2350,7 +2770,7 @@ axobject-query@^4.1.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
-babel-jest@^29.7.0:
+babel-jest@^29.2.1, babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
   integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==
@@ -2693,6 +3113,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -2700,6 +3128,16 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+char-regex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
+  integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+char-regex@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-2.0.2.tgz#81385bb071af4df774bff8721d0ca15ef29ea0bb"
+  integrity sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==
 
 chownr@^3.0.0:
   version "3.0.0"
@@ -2738,6 +3176,11 @@ ci-info@^3.2.0, ci-info@^3.3.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
+cjs-module-lexer@^1.0.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz#0f79731eb8cfe1ec72acd4066efac9d61991b00d"
+  integrity sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -2763,6 +3206,16 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
+
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
+
+collect-v8-coverage@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz#cc1f01eb8d02298cbc9a437c74c70ab4e5210b80"
+  integrity sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==
 
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
@@ -2803,6 +3256,13 @@ color@^3.1.3:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.4"
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 commander@^12.0.0:
   version "12.1.0"
@@ -2885,6 +3345,19 @@ cosmiconfig@^8.1.3:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
     path-type "^4.0.0"
+
+create-jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/create-jest/-/create-jest-29.7.0.tgz#a355c5b3cb1e1af02ba177fe7afd7feee49a5320"
+  integrity sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    jest-config "^29.7.0"
+    jest-util "^29.7.0"
+    prompts "^2.0.1"
 
 cross-fetch@^3.1.5:
   version "3.2.0"
@@ -2975,6 +3448,23 @@ csso@^5.0.5:
   dependencies:
     css-tree "~2.2.0"
 
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
+
+cssom@~0.3.6:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssstyle@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+  dependencies:
+    cssom "~0.3.6"
+
 csstype@3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
@@ -2989,6 +3479,15 @@ damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
+
+data-urls@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"
+  integrity sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==
+  dependencies:
+    abab "^2.0.6"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
 
 data-view-buffer@^1.0.2:
   version "1.0.2"
@@ -3050,17 +3549,27 @@ debug@^4.1.0:
   dependencies:
     ms "2.1.2"
 
-debug@^4.4.3:
+debug@^4.1.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
+decimal.js@^10.4.2:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
+
 decode-uri-component@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+
+dedent@^1.0.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.2.tgz#34e2264ab538301e27cf7b07bf2369c19baa8dd9"
+  integrity sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -3072,7 +3581,7 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.3.1:
+deepmerge@^4.2.2, deepmerge@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
@@ -3114,6 +3623,11 @@ define-properties@^1.2.1:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -3133,6 +3647,16 @@ detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+detect-newline@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -3161,6 +3685,13 @@ domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domexception@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
+  integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
+  dependencies:
+    webidl-conversions "^7.0.0"
 
 domhandler@^5.0.2, domhandler@^5.0.3:
   version "5.0.3"
@@ -3222,6 +3753,11 @@ electron-to-chromium@^1.5.173:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.179.tgz#453d53f360014a2604d40ccd41c4ea0a6e31b99a"
   integrity sha512-UWKi/EbBopgfFsc5k61wFpV7WrnnSlSzW/e2XcBmS6qKYTivZlLtoll5/rdqRTxGglGHkmkW0j0pFNJG10EUIQ==
 
+emittery@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
+  integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -3246,6 +3782,11 @@ entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 env-editor@^0.4.1:
   version "0.4.2"
@@ -3461,6 +4002,17 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escodegen@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
+  integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-config-airbnb-base@^15.0.0:
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz#6b09add90ac79c2f8d723a2580e07f3925afd236"
@@ -3655,7 +4207,7 @@ espree@^9.6.0, espree@^9.6.1:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -3703,6 +4255,37 @@ exec-async@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/exec-async/-/exec-async-2.2.0.tgz#c7c5ad2eef3478d38390c6dd3acfe8af0efc8301"
   integrity sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==
+
+execa@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+  integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
+
+expect@^29.0.0, expect@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
+  integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
+  dependencies:
+    "@jest/expect-utils" "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
 
 expo-asset@~12.0.12:
   version "12.0.12"
@@ -3962,7 +4545,7 @@ finalhandler@1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-up@^4.1.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -4013,6 +4596,17 @@ for-each@^0.3.3, for-each@^0.3.5:
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
+
+form-data@^4.0.0:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 freeport-async@^2.0.0:
   version "2.0.0"
@@ -4116,6 +4710,11 @@ get-proto@^1.0.0, get-proto@^1.0.1:
   dependencies:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
+
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-symbol-description@^1.1.0:
   version "1.1.0"
@@ -4313,6 +4912,18 @@ hosted-git-info@^7.0.0:
   dependencies:
     lru-cache "^10.0.1"
 
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
 html-parse-stringify@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
@@ -4331,6 +4942,23 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 https-proxy-agent@^7.0.5:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
@@ -4338,6 +4966,11 @@ https-proxy-agent@^7.0.5:
   dependencies:
     agent-base "^7.1.2"
     debug "4"
+
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 hyphenate-style-name@^1.0.3:
   version "1.0.4"
@@ -4350,6 +4983,13 @@ i18next@^25.7.3:
   integrity sha512-2XaT+HpYGuc2uTExq9TVRhLsso+Dxym6PWaKpn36wfBmTI779OQ7iP/XaZHzrnGyzU4SHpFrTYLKfVyBfAhVNA==
   dependencies:
     "@babel/runtime" "^7.28.4"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -4381,10 +5021,23 @@ import-fresh@^3.2.1, import-fresh@^3.3.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-local@^3.0.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.2.0.tgz#c3d5c745798c02a6f8b897726aba5100186ee260"
+  integrity sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -4552,6 +5205,11 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-generator-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
 is-generator-function@^1.0.10:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
@@ -4608,6 +5266,11 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-regex@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
@@ -4636,6 +5299,11 @@ is-shared-array-buffer@^1.0.4:
   integrity sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==
   dependencies:
     call-bound "^1.0.3"
+
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 is-string@^1.0.5:
   version "1.0.5"
@@ -4710,7 +5378,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-istanbul-lib-coverage@^3.2.0:
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
   integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
@@ -4726,6 +5394,43 @@ istanbul-lib-instrument@^5.0.4:
     istanbul-lib-coverage "^3.2.0"
     semver "^6.3.0"
 
+istanbul-lib-instrument@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz#fa15401df6c15874bcb2105f773325d78c666765"
+  integrity sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==
+  dependencies:
+    "@babel/core" "^7.23.9"
+    "@babel/parser" "^7.23.9"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^7.5.4"
+
+istanbul-lib-report@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz#895f3a709fcfba34c6de5a42939022f3e4358551"
+  integrity sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+    source-map "^0.6.1"
+
+istanbul-reports@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 iterator.prototype@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/iterator.prototype/-/iterator.prototype-1.1.5.tgz#12c959a29de32de0aa3bbbb801f4d777066dae39"
@@ -4738,6 +5443,138 @@ iterator.prototype@^1.1.5:
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
 
+jest-changed-files@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.7.0.tgz#1c06d07e77c78e1585d020424dedc10d6e17ac3a"
+  integrity sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==
+  dependencies:
+    execa "^5.0.0"
+    jest-util "^29.7.0"
+    p-limit "^3.1.0"
+
+jest-circus@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.7.0.tgz#b6817a45fcc835d8b16d5962d0c026473ee3668a"
+  integrity sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/expect" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    dedent "^1.0.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^29.7.0"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    p-limit "^3.1.0"
+    pretty-format "^29.7.0"
+    pure-rand "^6.0.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
+jest-cli@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.7.0.tgz#5592c940798e0cae677eec169264f2d839a37995"
+  integrity sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==
+  dependencies:
+    "@jest/core" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    chalk "^4.0.0"
+    create-jest "^29.7.0"
+    exit "^0.1.2"
+    import-local "^3.0.2"
+    jest-config "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    yargs "^17.3.1"
+
+jest-config@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.7.0.tgz#bcbda8806dbcc01b1e316a46bb74085a84b0245f"
+  integrity sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/test-sequencer" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    babel-jest "^29.7.0"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    jest-circus "^29.7.0"
+    jest-environment-node "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-runner "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    micromatch "^4.0.4"
+    parse-json "^5.2.0"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    strip-json-comments "^3.1.1"
+
+jest-diff@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-30.4.1.tgz#26691c73975768409af4a66b2754cea3182aa2dc"
+  integrity sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==
+  dependencies:
+    "@jest/diff-sequences" "30.4.0"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.4.1"
+
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-docblock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.7.0.tgz#8fddb6adc3cdc955c93e2a87f61cfd350d5d119a"
+  integrity sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-each@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-29.7.0.tgz#162a9b3f2328bdd991beaabffbb74745e56577d1"
+  integrity sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    chalk "^4.0.0"
+    jest-get-type "^29.6.3"
+    jest-util "^29.7.0"
+    pretty-format "^29.7.0"
+
+jest-environment-jsdom@^29.2.1:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz#d206fa3551933c3fd519e5dfdb58a0f5139a837f"
+  integrity sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/jsdom" "^20.0.0"
+    "@types/node" "*"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
+    jsdom "^20.0.0"
+
 jest-environment-node@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.7.0.tgz#0b93e111dda8ec120bc8300e6d1fb9576e164376"
@@ -4749,6 +5586,26 @@ jest-environment-node@^29.7.0:
     "@types/node" "*"
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
+
+jest-expo@~54.0.0:
+  version "54.0.17"
+  resolved "https://registry.yarnpkg.com/jest-expo/-/jest-expo-54.0.17.tgz#c4b905097889340fe44f868d601c165c113ddc55"
+  integrity sha512-LyIhrsP4xvHEEcR1R024u/LBj3uPpAgB+UljgV+YXWkEHjprnr0KpE4tROsMNYCVTM1pPlAnPuoBmn5gnAN9KA==
+  dependencies:
+    "@expo/config" "~12.0.13"
+    "@expo/json-file" "^10.0.8"
+    "@jest/create-cache-key-function" "^29.2.1"
+    "@jest/globals" "^29.2.1"
+    babel-jest "^29.2.1"
+    jest-environment-jsdom "^29.2.1"
+    jest-snapshot "^29.2.1"
+    jest-watch-select-projects "^2.0.0"
+    jest-watch-typeahead "2.2.1"
+    json5 "^2.2.3"
+    lodash "^4.17.19"
+    react-test-renderer "19.1.0"
+    server-only "^0.0.1"
+    stacktrace-js "^2.0.2"
 
 jest-get-type@^29.6.3:
   version "29.6.3"
@@ -4774,6 +5631,34 @@ jest-haste-map@^29.7.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-leak-detector@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728"
+  integrity sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==
+  dependencies:
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-matcher-utils@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
+  integrity sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-matcher-utils@^30.0.5:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz#3fee8c89dbd8fc6e60eb590def9897e18f110ec4"
+  integrity sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    jest-diff "30.4.1"
+    pretty-format "30.4.1"
+
 jest-message-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
@@ -4798,10 +5683,119 @@ jest-mock@^29.7.0:
     "@types/node" "*"
     jest-util "^29.7.0"
 
-jest-regex-util@^29.6.3:
+jest-pnp-resolver@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz#930b1546164d4ad5937d5540e711d4d38d4cad2e"
+  integrity sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==
+
+jest-regex-util@^29.0.0, jest-regex-util@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.6.3.tgz#4a556d9c776af68e1c5f48194f4d0327d24e8a52"
   integrity sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==
+
+jest-resolve-dependencies@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz#1b04f2c095f37fc776ff40803dc92921b1e88428"
+  integrity sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==
+  dependencies:
+    jest-regex-util "^29.6.3"
+    jest-snapshot "^29.7.0"
+
+jest-resolve@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.7.0.tgz#64d6a8992dd26f635ab0c01e5eef4399c6bcbc30"
+  integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
+  dependencies:
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    jest-pnp-resolver "^1.2.2"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    resolve "^1.20.0"
+    resolve.exports "^2.0.0"
+    slash "^3.0.0"
+
+jest-runner@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.7.0.tgz#809af072d408a53dcfd2e849a4c976d3132f718e"
+  integrity sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==
+  dependencies:
+    "@jest/console" "^29.7.0"
+    "@jest/environment" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    emittery "^0.13.1"
+    graceful-fs "^4.2.9"
+    jest-docblock "^29.7.0"
+    jest-environment-node "^29.7.0"
+    jest-haste-map "^29.7.0"
+    jest-leak-detector "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-resolve "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-util "^29.7.0"
+    jest-watcher "^29.7.0"
+    jest-worker "^29.7.0"
+    p-limit "^3.1.0"
+    source-map-support "0.5.13"
+
+jest-runtime@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.7.0.tgz#efecb3141cf7d3767a3a0cc8f7c9990587d3d817"
+  integrity sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/globals" "^29.7.0"
+    "@jest/source-map" "^29.6.3"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    cjs-module-lexer "^1.0.0"
+    collect-v8-coverage "^1.0.0"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+
+jest-snapshot@^29.2.1, jest-snapshot@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.7.0.tgz#c2c574c3f51865da1bb329036778a69bf88a6be5"
+  integrity sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@babel/generator" "^7.7.2"
+    "@babel/plugin-syntax-jsx" "^7.7.2"
+    "@babel/plugin-syntax-typescript" "^7.7.2"
+    "@babel/types" "^7.3.3"
+    "@jest/expect-utils" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    babel-preset-current-node-syntax "^1.0.0"
+    chalk "^4.0.0"
+    expect "^29.7.0"
+    graceful-fs "^4.2.9"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    natural-compare "^1.4.0"
+    pretty-format "^29.7.0"
+    semver "^7.5.3"
 
 jest-util@^29.7.0:
   version "29.7.0"
@@ -4827,6 +5821,42 @@ jest-validate@^29.7.0:
     leven "^3.1.0"
     pretty-format "^29.7.0"
 
+jest-watch-select-projects@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-watch-select-projects/-/jest-watch-select-projects-2.0.0.tgz#4373d7e4de862aae28b46e036b669a4c913ea867"
+  integrity sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    chalk "^3.0.0"
+    prompts "^2.2.1"
+
+jest-watch-typeahead@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-2.2.1.tgz#36601520a2a30fd561788552dbda9c76bb44814a"
+  integrity sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==
+  dependencies:
+    ansi-escapes "^6.0.0"
+    chalk "^4.0.0"
+    jest-regex-util "^29.0.0"
+    jest-watcher "^29.0.0"
+    slash "^5.0.0"
+    string-length "^5.0.1"
+    strip-ansi "^7.0.1"
+
+jest-watcher@^29.0.0, jest-watcher@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.7.0.tgz#7810d30d619c3a62093223ce6bb359ca1b28a2f2"
+  integrity sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==
+  dependencies:
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    emittery "^0.13.1"
+    jest-util "^29.7.0"
+    string-length "^4.0.1"
+
 jest-worker@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
@@ -4836,6 +5866,16 @@ jest-worker@^29.7.0:
     jest-util "^29.7.0"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
+
+jest@~29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
+  integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
+  dependencies:
+    "@jest/core" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    import-local "^3.0.2"
+    jest-cli "^29.7.0"
 
 jimp-compact@0.16.1:
   version "0.16.1"
@@ -4866,6 +5906,38 @@ jsc-safe-url@^0.2.2, jsc-safe-url@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz#141c14fbb43791e88d5dc64e85a374575a83477a"
   integrity sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==
+
+jsdom@^20.0.0:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.3.tgz#886a41ba1d4726f67a8858028c99489fed6ad4db"
+  integrity sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==
+  dependencies:
+    abab "^2.0.6"
+    acorn "^8.8.1"
+    acorn-globals "^7.0.0"
+    cssom "^0.5.0"
+    cssstyle "^2.3.0"
+    data-urls "^3.0.2"
+    decimal.js "^10.4.2"
+    domexception "^4.0.0"
+    escodegen "^2.0.0"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.1"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.2"
+    parse5 "^7.1.1"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.1.2"
+    w3c-xmlserializer "^4.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^2.0.0"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
+    ws "^8.11.0"
+    xml-name-validator "^4.0.0"
 
 jsesc@^3.0.2:
   version "3.1.0"
@@ -5127,6 +6199,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -5400,7 +6479,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
   integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
-mime-types@^2.1.27, mime-types@~2.1.34:
+mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -5416,6 +6495,16 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimatch@^10.1.1:
   version "10.1.1"
@@ -5590,6 +6679,13 @@ npm-package-arg@^11.0.0:
     semver "^7.3.5"
     validate-npm-package-name "^5.0.0"
 
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
 nth-check@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
@@ -5601,6 +6697,11 @@ nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
+
+nwsapi@^2.2.2:
+  version "2.2.24"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.24.tgz#f8927043d4c9b516abdebe804a32c8d1f9484d1f"
+  integrity sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==
 
 ob1@0.83.3:
   version "0.83.3"
@@ -5723,6 +6824,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+onetime@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+  dependencies:
+    mimic-fn "^2.1.0"
+
 open@^7.0.3:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
@@ -5831,6 +6939,13 @@ parse-png@^2.1.0:
   dependencies:
     pngjs "^3.3.0"
 
+parse5@^7.0.0, parse5@^7.1.1:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -5851,7 +6966,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -5903,6 +7018,13 @@ pirates@^4.0.1, pirates@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
 
 plist@^3.0.1:
   version "3.0.1"
@@ -5964,7 +7086,17 @@ pretty-bytes@^5.6.0:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
-pretty-format@^29.7.0:
+pretty-format@30.4.1, pretty-format@^30.0.5:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-30.4.1.tgz#0911652e92e1e91f475e3e6a16e628e50649ea69"
+  integrity sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==
+  dependencies:
+    "@jest/schemas" "30.4.1"
+    ansi-styles "^5.2.0"
+    react-is-18 "npm:react-is@^18.3.1"
+    react-is-19 "npm:react-is@^19.2.5"
+
+pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
@@ -5997,7 +7129,7 @@ promise@^8.3.0:
   dependencies:
     asap "~2.0.6"
 
-prompts@^2.3.2:
+prompts@^2.0.1, prompts@^2.2.1, prompts@^2.3.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
@@ -6014,15 +7146,27 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+psl@^1.1.33:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-punycode@^2.1.1:
+punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+pure-rand@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
+  integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
 qrcode-terminal@0.11.0:
   version "0.11.0"
@@ -6038,6 +7182,11 @@ query-string@^7.1.3:
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -6099,6 +7248,16 @@ react-i18next@^16.5.0:
     "@babel/runtime" "^7.27.6"
     html-parse-stringify "^3.0.1"
     use-sync-external-store "^1.6.0"
+
+"react-is-18@npm:react-is@^18.3.1":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+"react-is-19@npm:react-is@^19.2.5":
+  version "19.2.8"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.8.tgz#09826f9fbc187bc668e3e5c62edc001f804d5018"
+  integrity sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -6266,10 +7425,26 @@ react-refresh@^0.14.0, react-refresh@^0.14.2:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
+react-test-renderer@19.1.0:
+  version "19.1.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.1.0.tgz#89e1baa9e45a6da064b9760f92251d5b8e1f34ab"
+  integrity sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==
+  dependencies:
+    react-is "^19.1.0"
+    scheduler "^0.26.0"
+
 react@19.1.0:
   version "19.1.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.1.0.tgz#926864b6c48da7627f004795d6cce50e90793b75"
   integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 reflect.getprototypeof@^1.0.10, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -6357,6 +7532,18 @@ requireg@^0.2.2:
     rc "~1.2.7"
     resolve "~1.7.1"
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
+resolve-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  dependencies:
+    resolve-from "^5.0.0"
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -6379,10 +7566,20 @@ resolve-workspace-root@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve-workspace-root/-/resolve-workspace-root-2.0.0.tgz#a0098daa0067cd0efa6eb525c57c8fb4a61e78f8"
   integrity sha512-IsaBUZETJD5WsI11Wt8PKHwaIe45or6pwNc8yflvLJ4DWtImK9kuLoH5kUva/2Mmx/RdIyr4aONNSa2v9LTJsw==
 
-resolve.exports@^2.0.3:
+resolve.exports@^2.0.0, resolve.exports@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
+
+resolve@^1.20.0:
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.22.10, resolve@^1.22.2:
   version "1.22.10"
@@ -6477,10 +7674,22 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 sax@>=0.6.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
   integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@0.26.0, scheduler@^0.26.0:
   version "0.26.0"
@@ -6502,7 +7711,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.7.3:
+semver@^7.5.3, semver@^7.7.3:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
@@ -6559,6 +7768,11 @@ serve-static@^1.16.2:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.19.0"
+
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -6668,7 +7882,7 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-signal-exit@^3.0.7:
+signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -6699,6 +7913,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slash@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-5.1.0.tgz#be3adddcdf09ac38eebe8dcdc7b1a57a75b095ce"
+  integrity sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==
+
 slugify@^1.3.4, slugify@^1.6.6:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.6.tgz#2d4ac0eacb47add6af9e04d3be79319cbcc7924b"
@@ -6717,6 +7936,14 @@ source-map-js@^1.0.1, source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+source-map-support@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@~0.5.20, source-map-support@~0.5.21:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
@@ -6725,12 +7952,17 @@ source-map-support@~0.5.20, source-map-support@~0.5.21:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==
+
 source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -6745,6 +7977,13 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+stack-generator@^2.0.5:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.10.tgz#8ae171e985ed62287d4f1ed55a1633b3fb53bb4d"
+  integrity sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==
+  dependencies:
+    stackframe "^1.3.4"
+
 stack-utils@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
@@ -6756,6 +7995,23 @@ stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
   integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
+
+stacktrace-gps@^3.0.4:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz#0c40b24a9b119b20da4525c398795338966a2fb0"
+  integrity sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.3.4"
+
+stacktrace-js@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.2.tgz#4ca93ea9f494752d55709a081d400fdaebee897b"
+  integrity sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==
+  dependencies:
+    error-stack-parser "^2.0.6"
+    stack-generator "^2.0.5"
+    stacktrace-gps "^3.0.4"
 
 stacktrace-parser@^0.1.10:
   version "0.1.11"
@@ -6791,6 +8047,22 @@ strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
+
+string-length@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
+  integrity sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==
+  dependencies:
+    char-regex "^1.0.2"
+    strip-ansi "^6.0.0"
+
+string-length@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-5.0.1.tgz#3d647f497b6e8e8d41e422f7e0b23bc536c8381e"
+  integrity sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==
+  dependencies:
+    char-regex "^2.0.0"
+    strip-ansi "^7.0.1"
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
@@ -6916,10 +8188,34 @@ strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
+
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -7033,6 +8329,11 @@ swr@^2.5.1:
   dependencies:
     dequal "^2.0.3"
     use-sync-external-store "^1.6.0"
+
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 synckit@^0.11.13:
   version "0.11.13"
@@ -7155,6 +8456,23 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+tough-cookie@^4.1.2:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
+  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
+  dependencies:
+    punycode "^2.1.1"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -7323,6 +8641,11 @@ unique-string@~2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -7342,6 +8665,14 @@ uri-js@^4.2.2:
   integrity sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 use-latest-callback@^0.2.4:
   version "0.2.4"
@@ -7368,6 +8699,15 @@ uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
+v8-to-istanbul@^9.0.1:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
+  integrity sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^2.0.0"
+
 validate-npm-package-name@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
@@ -7387,6 +8727,13 @@ void-elements@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
   integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
+
+w3c-xmlserializer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz#aebdc84920d806222936e3cdce408e32488a3073"
+  integrity sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==
+  dependencies:
+    xml-name-validator "^4.0.0"
 
 walker@^1.0.7:
   version "1.0.7"
@@ -7424,10 +8771,27 @@ webidl-conversions@^5.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
   integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
 
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-fetch@^3.0.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
   integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
 
 whatwg-url-without-unicode@8.0.0-3:
   version "8.0.0-3"
@@ -7437,6 +8801,14 @@ whatwg-url-without-unicode@8.0.0-3:
     buffer "^5.4.3"
     punycode "^2.1.1"
     webidl-conversions "^5.0.0"
+
+whatwg-url@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
+  dependencies:
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -7555,6 +8927,11 @@ ws@^7.5.10:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
+ws@^8.11.0:
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.3.tgz#660b4faddb6a3e575c86e078126919961f4de4fc"
+  integrity sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==
+
 ws@^8.12.1:
   version "8.18.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
@@ -7567,6 +8944,11 @@ xcode@^3.0.1:
   dependencies:
     simple-plist "^1.1.0"
     uuid "^7.0.3"
+
+xml-name-validator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
 
 xml2js@0.6.0:
   version "0.6.0"
@@ -7590,6 +8972,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xmldom@0.1.x:
   version "0.1.31"
@@ -7620,6 +9007,19 @@ yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.3.1:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yargs@^17.6.2:
   version "17.7.2"


### PR DESCRIPTION
## Summary

Adds a full Jest test suite to the app, raising line coverage from ~0% to ~97%. Includes test infrastructure and tests for services, contexts, shared components, form pages, camera/map pages, and navigation routes.

## Changes

- **Test infrastructure**: `jest.config.js`, `jest/setup.ts`, `jest/environmentMock.ts`, `jest/svgMock.ts`, `src/testUtils.tsx` (`renderWithSWR`), `test`/`test:watch` scripts, `tsconfig` + `.eslintrc` updates, dev deps (`jest-expo`, `jest`, `@testing-library/react-native`, `react-test-renderer`).
- **Bug fix**: `createRows` in `ProfileList` padded a phantom row when the profile grid was full.
- **Testability**: `VaccineCard` exposes `getNextVaccines` and `formatAgeRange`; form inputs/pages exported as needed.
- **Tests (74 across 23 suites)**:
  - Services: auth, user, vaccine, campaign
  - `contexts/auth`
  - Components: `Button`, `Input`, `VaccineCard`
  - Pages: `Login`, `SignUp`, `AddDependent`, `ProfileList`, `Dependent`, `MyVaccines`, `Campaigns`, `CampaignDetail`, `ApplyVaccine`, `CampaignMap`
  - Routes: `Routes`, `SignInStack`, `SignOutStack`
  - `httpClient`, i18n locales

## Coverage

| Metric | Value |
|---|---|
| Statements | 96.8% |
| Lines | 96.8% |
| Functions | 88.7% |
| Branches | 80.2% |

Remaining uncovered areas are low-value: `onSubmitEditing` ref-focus handlers, styled branches, type-only `src/@types`, and the `src/styles` barrel.

## Notes

This branch was rebased onto `origin/main` (including the react-hook-form + Zod migration) and force-pushed.